### PR TITLE
fix: always print out the app url

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -85,8 +85,8 @@ class Deploy extends BaseCommand {
         if (!flags.actions) {
           if (fs.existsSync('web-src/')) {
             const url = await scripts.deployUI()
-            if (flags.verbose) this.log(chalk.blue(url))
-            else open(url) // do not open if verbose as the user probably wants to look at the console
+            this.log(chalk.green(chalk.bold(`url: ${url}`)))
+            open(url) // do not open if verbose as the user probably wants to look at the console
           } else {
             this.log('no web-src, skipping web-src deploy')
           }

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -85,8 +85,10 @@ class Deploy extends BaseCommand {
         if (!flags.actions) {
           if (fs.existsSync('web-src/')) {
             const url = await scripts.deployUI()
-            this.log(chalk.green(chalk.bold(`url: ${url}`)))
-            open(url) // do not open if verbose as the user probably wants to look at the console
+            this.log(chalk.green(chalk.bold(`url: ${url}`))) // always log the url
+            if (!flags.verbose) {
+              open(url) // do not open if verbose as the user probably wants to look at the console
+            }
           } else {
             this.log('no web-src, skipping web-src deploy')
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Users after a deploy don't have a record in the run log of what the app url is at. It was hidden under a verbose flag. This change makes it always print it out.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Bstter developer experience.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
