### PR TITLE
ACNA-613 - Add `app:use` and `app:create --import` command/flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ USAGE
 * [`@adobe/aio-cli-plugin-app app:run`](#adobeaio-cli-plugin-app-apprun)
 * [`@adobe/aio-cli-plugin-app app:test`](#adobeaio-cli-plugin-app-apptest)
 * [`@adobe/aio-cli-plugin-app app:undeploy`](#adobeaio-cli-plugin-app-appundeploy)
+* [`@adobe/aio-cli-plugin-app app:use CONFIG_FILE_PATH`](#adobeaio-cli-plugin-app-appuse-config_file_path)
 
 ## `@adobe/aio-cli-plugin-app app`
 
@@ -121,8 +122,9 @@ ARGUMENTS
   PATH  [default: .] Path to the app directory
 
 OPTIONS
-  -v, --verbose  Verbose output
-  --version      Show version
+  -i, --import=import  Import an Adobe I/O Developer Console configuration file
+  -v, --verbose        Verbose output
+  --version            Show version
 ```
 
 _See code: [src/commands/app/create.js](https://github.com/adobe/aio-cli-plugin-app/blob/0.4.0/src/commands/app/create.js)_
@@ -266,4 +268,23 @@ OPTIONS
 ```
 
 _See code: [src/commands/app/undeploy.js](https://github.com/adobe/aio-cli-plugin-app/blob/0.4.0/src/commands/app/undeploy.js)_
+
+## `@adobe/aio-cli-plugin-app app:use CONFIG_FILE_PATH`
+
+Import an Adobe I/O Developer Console configuration file
+
+```
+USAGE
+  $ @adobe/aio-cli-plugin-app app:use CONFIG_FILE_PATH
+
+ARGUMENTS
+  CONFIG_FILE_PATH  path to an Adobe I/O Developer Console configuration file
+
+OPTIONS
+  -v, --verbose    Verbose output
+  -w, --overwrite  Overwrite any .aio and .env files during import of the Adobe I/O Developer Console configuration file
+  --version        Show version
+```
+
+_See code: [src/commands/app/use.js](https://github.com/adobe/aio-cli-plugin-app/blob/0.4.0/src/commands/app/use.js)_
 <!-- commandsstop -->

--- a/src/commands/app/create.js
+++ b/src/commands/app/create.js
@@ -31,7 +31,7 @@ class Create extends BaseCommand {
     // note that the CWD has been changed by the init command above (to a resolved args.path),
     // thus we install the config into the CWD
     if (flags.import) {
-      await importConfigJson(configFilePath, process.cwd(), true)
+      await importConfigJson(configFilePath, process.cwd(), { interactive: true })
     }
   }
 }

--- a/src/commands/app/use.js
+++ b/src/commands/app/use.js
@@ -17,7 +17,7 @@ class Use extends BaseCommand {
   async run () {
     const { args, flags } = this.parse(Use)
 
-    return importConfigJson(args.config_file_path, process.cwd(), flags.overwrite)
+    return importConfigJson(args.config_file_path, process.cwd(), { overwrite: flags.overwrite })
   }
 }
 

--- a/src/commands/app/use.js
+++ b/src/commands/app/use.js
@@ -16,8 +16,14 @@ const { flags } = require('@oclif/command')
 class Use extends BaseCommand {
   async run () {
     const { args, flags } = this.parse(Use)
+    const overwrite = flags.overwrite
+    let interactive = true
 
-    return importConfigJson(args.config_file_path, process.cwd(), { overwrite: flags.overwrite })
+    if (overwrite) {
+      interactive = false
+    }
+
+    return importConfigJson(args.config_file_path, process.cwd(), { interactive, overwrite })
   }
 }
 

--- a/src/commands/app/use.js
+++ b/src/commands/app/use.js
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const BaseCommand = require('../../BaseCommand')
+const { importConfigJson } = require('../../lib/import')
+const { flags } = require('@oclif/command')
+
+class Use extends BaseCommand {
+  async run () {
+    const { args, flags } = this.parse(Use)
+
+    return importConfigJson(args.config_file_path, process.cwd(), flags.overwrite)
+  }
+}
+
+Use.description = `Import an Adobe I/O Developer Console configuration file
+`
+
+Use.flags = {
+  ...BaseCommand.flags,
+  overwrite: flags.boolean({
+    description: 'Overwrite any .aio and .env files during import of the Adobe I/O Developer Console configuration file',
+    char: 'w',
+    default: false
+  })
+}
+
+Use.args = [
+  {
+    name: 'config_file_path',
+    description: 'path to an Adobe I/O Developer Console configuration file',
+    required: true
+  }
+]
+
+module.exports = Use

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -12,11 +12,33 @@ governing permissions and limitations under the License.
 const debug = require('debug')('aio-cli-plugin-app:import')
 const path = require('path')
 const fs = require('fs-extra')
+const inquirer = require('inquirer')
 
 const AIO_FILE = '.aio'
 const ENV_FILE = '.env'
 const AIO_ENV_PREFIX = 'AIO_'
 const AIO_ENV_SEPARATOR = '_'
+
+/**
+ * Confirmation prompt for overwriting a file if it already exists.
+ *
+ * @param {string} filePath the file to ovewrite
+ * @return {boolean} true if confirm overwrite, false if not
+ */
+async function confirmOverwrite (filePath) {
+  if (fs.existsSync(filePath)) {
+    return inquirer
+      .prompt({
+        name: 'confirm',
+        type: 'confirm',
+        message: `The file ${filePath} already exists. Overwrite? (y/N)`,
+        default: false
+      })
+      .then(answers => answers.confirm)
+  } else {
+    return true
+  }
+}
 
 /**
  * Transform a json object to a flattened version. Any nesting is separated by the `separator` string.
@@ -67,10 +89,12 @@ function flattenObjectWithSeparator (json, result = {}, prefix = AIO_ENV_PREFIX,
  *
  * @param {object} json the json object to transform and write to disk
  * @param {string} parentFolder the parent folder to write the .env file to
- * @param {boolean} [overwrite=false] set to true to overwrite the existing .env file
+ * @param {object} flags] flags for file writing
+ * @param {boolean} [flags.overwrite=false] set to true to overwrite the existing .env file
+ * @param {boolean} [flags.interactive=false] set to true to prompt the user for file overwrite
  */
-async function writeEnv (json, parentFolder, overwrite = false) {
-  debug(`writeEnv - json: ${JSON.stringify(json)} parentFolder:${parentFolder} overwrite:${overwrite}`)
+async function writeEnv (json, parentFolder, { overwrite = false, interactive = false }) {
+  debug(`writeEnv - json: ${JSON.stringify(json)} parentFolder:${parentFolder} overwrite:${overwrite} interactive:${interactive}`)
 
   const destination = path.join(parentFolder, ENV_FILE)
   debug(`writeEnv - destination: ${destination}`)
@@ -85,6 +109,15 @@ async function writeEnv (json, parentFolder, overwrite = false) {
 
   debug(`writeEnv - data: ${data}`)
 
+  if (interactive) {
+    overwrite = await confirmOverwrite(destination)
+    debug(`writeEnv - confirmOverwrite: ${overwrite}`)
+
+    if (!overwrite) {
+      return
+    }
+  }
+
   return fs.writeFile(destination, data, {
     flag: overwrite ? 'w' : 'wx'
   })
@@ -95,13 +128,24 @@ async function writeEnv (json, parentFolder, overwrite = false) {
  *
  * @param {object} json the json object to write to disk
  * @param {string} parentFolder the parent folder to write the .aio file to
- * @param {boolean} [overwrite=false] set to true to overwrite the existing .aio file
+ * @param {object} flags] flags for file writing
+ * @param {boolean} [flags.overwrite=false] set to true to overwrite the existing .env file
+ * @param {boolean} [flags.interactive=false] set to true to prompt the user for file overwrite
  */
-async function writeAio (json, parentFolder, overwrite = false) {
-  debug(`writeAio - json: ${JSON.stringify(json, null, 2)} parentFolder:${parentFolder} overwrite:${overwrite}`)
+async function writeAio (json, parentFolder, { overwrite = false, interactive = false }) {
+  debug(`writeAio - json: ${JSON.stringify(json, null, 2)} parentFolder:${parentFolder} overwrite:${overwrite} interactive:${interactive}`)
 
   const destination = path.join(parentFolder, AIO_FILE)
   debug(`writeAio - destination: ${destination}`)
+
+  if (interactive) {
+    overwrite = await confirmOverwrite(destination)
+    debug(`writeAio - confirmOverwrite: ${overwrite}`)
+
+    if (!overwrite) {
+      return
+    }
+  }
 
   return fs.writeJson(destination, json, {
     spaces: 2,
@@ -116,21 +160,21 @@ async function writeAio (json, parentFolder, overwrite = false) {
  * @param {string} [writeToFolder=the current working directory] the path to the folder to write the .env and .aio files to
   * @param {boolean} [overwrite=false] set to true to overwrite any existing files
 */
-async function importConfigJson (configFileLocation, writeToFolder = process.cwd(), overwrite = false) {
-  debug(`importConfigJson - configFileLocation: ${configFileLocation} writeToFolder:${writeToFolder} overwrite:${overwrite}`)
+async function importConfigJson (configFileLocation, writeToFolder = process.cwd(), { overwrite = false, interactive = false }) {
+  debug(`importConfigJson - configFileLocation: ${configFileLocation} writeToFolder:${writeToFolder} overwrite:${overwrite} interactive:${interactive}`)
 
   const config = await fs.readJson(configFileLocation)
   const { runtime, credentials } = config
 
   debug(`importConfigJson - config:${JSON.stringify(config, null, 2)} `)
 
-  await writeEnv({ runtime, credentials }, writeToFolder, overwrite)
+  await writeEnv({ runtime, credentials }, writeToFolder, { overwrite, interactive })
 
   // remove the credentials
   delete config.runtime
   delete config.credentials
 
-  return writeAio(config, writeToFolder, overwrite)
+  return writeAio(config, writeToFolder, { overwrite, interactive })
 }
 
 module.exports = {

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -93,7 +93,7 @@ function flattenObjectWithSeparator (json, result = {}, prefix = AIO_ENV_PREFIX,
  * @param {boolean} [flags.overwrite=false] set to true to overwrite the existing .env file
  * @param {boolean} [flags.interactive=false] set to true to prompt the user for file overwrite
  */
-async function writeEnv (json, parentFolder, { overwrite = false, interactive = false }) {
+async function writeEnv (json, parentFolder, { overwrite = false, interactive = false } = {}) {
   debug(`writeEnv - json: ${JSON.stringify(json)} parentFolder:${parentFolder} overwrite:${overwrite} interactive:${interactive}`)
 
   const destination = path.join(parentFolder, ENV_FILE)
@@ -132,7 +132,7 @@ async function writeEnv (json, parentFolder, { overwrite = false, interactive = 
  * @param {boolean} [flags.overwrite=false] set to true to overwrite the existing .env file
  * @param {boolean} [flags.interactive=false] set to true to prompt the user for file overwrite
  */
-async function writeAio (json, parentFolder, { overwrite = false, interactive = false }) {
+async function writeAio (json, parentFolder, { overwrite = false, interactive = false } = {}) {
   debug(`writeAio - json: ${JSON.stringify(json, null, 2)} parentFolder:${parentFolder} overwrite:${overwrite} interactive:${interactive}`)
 
   const destination = path.join(parentFolder, AIO_FILE)
@@ -160,7 +160,7 @@ async function writeAio (json, parentFolder, { overwrite = false, interactive = 
  * @param {string} [writeToFolder=the current working directory] the path to the folder to write the .env and .aio files to
   * @param {boolean} [overwrite=false] set to true to overwrite any existing files
 */
-async function importConfigJson (configFileLocation, writeToFolder = process.cwd(), { overwrite = false, interactive = false }) {
+async function importConfigJson (configFileLocation, writeToFolder = process.cwd(), { overwrite = false, interactive = false } = {}) {
   debug(`importConfigJson - configFileLocation: ${configFileLocation} writeToFolder:${writeToFolder} overwrite:${overwrite} interactive:${interactive}`)
 
   const config = await fs.readJson(configFileLocation)

--- a/test/commands/app/create.test.js
+++ b/test/commands/app/create.test.js
@@ -13,6 +13,9 @@ governing permissions and limitations under the License.
 const TheCommand = require('../../../src/commands/app/create')
 const BaseCommand = require('../../../src/BaseCommand')
 const InitCommand = require('../../../src/commands/app/init')
+const importLib = require('../../../src/lib/import')
+
+jest.mock('../../../src/lib/import')
 
 beforeEach(() => {
   jest.restoreAllMocks()
@@ -43,9 +46,14 @@ describe('bad flags', () => {
 
 describe('runs', () => {
   test('Calls to InitCommand with -y', async () => {
-    // console.error('icm.run = ' + )
     const mySpy = jest.spyOn(InitCommand, 'run').mockImplementation(jest.fn())
     await TheCommand.run(['new-project'])
     expect(mySpy).toHaveBeenCalledWith(['new-project', '-y'])
+  })
+
+  test('import', async () => {
+    jest.spyOn(InitCommand, 'run').mockImplementation(jest.fn())
+    await TheCommand.run(['new-project', '--import', 'config-file'])
+    await expect(importLib.importConfigJson).toHaveBeenCalled()
   })
 })

--- a/test/commands/app/use.test.js
+++ b/test/commands/app/use.test.js
@@ -45,5 +45,7 @@ describe('bad flags', () => {
 
 test('runs', async () => {
   await TheCommand.run(['config-file'])
-  expect(importLib.importConfigJson).toHaveBeenCalled()
+  await TheCommand.run(['config-file', '--overwrite'])
+
+  expect(importLib.importConfigJson).toHaveBeenCalledTimes(2)
 })

--- a/test/commands/app/use.test.js
+++ b/test/commands/app/use.test.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const TheCommand = require('../../../src/commands/app/use')
+const BaseCommand = require('../../../src/BaseCommand')
+const importLib = require('../../../src/lib/import')
+
+jest.mock('../../../src/lib/import')
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('Command Prototype', () => {
+  test('exports', async () => {
+    expect(typeof TheCommand).toEqual('function')
+    expect(TheCommand.prototype instanceof BaseCommand).toBeTruthy()
+    expect(typeof TheCommand.description).toBe('string')
+  })
+})
+
+describe('bad flags', () => {
+  test('unknown', async () => {
+    const result = TheCommand.run(['.', '--wtf'])
+    expect(result instanceof Promise).toBeTruthy()
+    return new Promise((resolve, reject) => {
+      return result
+        .then(() => reject(new Error()))
+        .catch(res => {
+          expect(res).toEqual(new Error('Unexpected argument: --wtf\nSee more help with --help'))
+          resolve()
+        })
+    })
+  })
+})
+
+test('runs', async () => {
+  await TheCommand.run(['config-file'])
+  expect(importLib.importConfigJson).toHaveBeenCalled()
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add `app:use` command
- Add `app:create --import` flag

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Import Adobe I/O Console downloadable config file.

## How Has This Been Tested?

npm test
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
