### PR TITLE
fix: enforce validation rules on imported config

### DIFF
--- a/test/__fixtures__/config.1.aio
+++ b/test/__fixtures__/config.1.aio
@@ -1,4 +1,10 @@
 {
   "id": "this is some data",
-  "name": "my-name"
+  "name": "myname",
+  "project": {
+    "name": "projectname",
+    "org": {
+        "name": "orgname"
+    }
+  }
 }

--- a/test/__fixtures__/config.2.json
+++ b/test/__fixtures__/config.2.json
@@ -1,11 +1,11 @@
 {
   "id": "this is some data",
-  "name": "myname",
+  "name": "invalid-workspace-name",
   "project": {
-    "name": "projectname",
-    "org": {
-        "name": "orgname"
-    }
+      "name": "invalid-project-name",
+      "org": {
+          "name": "invalid-org-name"
+      }
   },
   "runtime": {
     "namespace": "my-namespace",

--- a/test/__fixtures__/config.3.json
+++ b/test/__fixtures__/config.3.json
@@ -1,0 +1,3 @@
+{
+  "id": "this is some data"
+}

--- a/test/commands/lib/import.test.js
+++ b/test/commands/lib/import.test.js
@@ -124,12 +124,8 @@ test('importConfigJson', async () => {
   await expect(fs.writeJson.mock.calls[1][2]).toMatchObject({ flag: 'wx' })
   await expect(fs.writeFile.mock.calls[1][2]).toMatchObject({ flag: 'wx' })
 
-  // empty config
-  fs.readJson.mockReturnValueOnce({})
-  await importConfigJson('/some/config/path') // third call
-
-  await expect(fs.writeJson).toHaveBeenCalledTimes(3)
-  await expect(fs.writeFile).toHaveBeenCalledTimes(3)
+  await expect(fs.writeJson).toHaveBeenCalledTimes(2)
+  await expect(fs.writeFile).toHaveBeenCalledTimes(2)
 })
 
 test('importConfigJson - interactive', async () => {
@@ -157,4 +153,15 @@ test('importConfigJson - interactive', async () => {
 
   await expect(fs.writeJson).toHaveBeenCalledTimes(1)
   await expect(fs.writeFile).toHaveBeenCalledTimes(1)
+})
+
+test('enforce alphanumeric content rules', async () => {
+  fs.readJson.mockReturnValueOnce(fixtureJson('config.2.json'))
+  await expect(importConfigJson('/some/config/path')).rejects.toThrow('Missing or invalid keys in config:')
+
+  fs.readJson.mockReturnValueOnce(fixtureJson('config.3.json')) // for coverage (missing keys)
+  await expect(importConfigJson('/some/config/path')).rejects.toThrow('Missing or invalid keys in config:')
+
+  await expect(fs.writeJson).toHaveBeenCalledTimes(0)
+  await expect(fs.writeFile).toHaveBeenCalledTimes(0)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For the imported config, we need to validate certain keys to match requirements.
For the workspace name, project name, and org name, they have to match: ^[a-zA-Z0-9]+$
(one or more alphanumeric characters only)

## Motivation and Context

Data validation

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
