### PR TITLE
run package.json scripts for [ pre | post ]-app-[ build | deploy | run ]

### DIFF
--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -20,6 +20,7 @@ const { flags } = require('@oclif/command')
 
 const BaseCommand = require('../../BaseCommand')
 const AppScripts = require('@adobe/aio-app-scripts')
+const { runPackageScript } = require('../../lib/app-helper')
 
 const PRIVATE_KEY_PATH = 'dist/dev-keys/private.key'
 const PUB_CERT_PATH = 'dist/dev-keys/cert-pub.crt'
@@ -30,6 +31,13 @@ class Run extends BaseCommand {
     const runOptions = {
       logLevel: flags.verbose ? 4 : 2
     }
+
+    try {
+      await runPackageScript('pre-app-run')
+    } catch (err) {
+      // this is assumed to be a missing script error
+    }
+
     /* check if there are certificates available, and generate them if not ... */
     try {
       fs.ensureDirSync(path.dirname(PRIVATE_KEY_PATH))
@@ -81,6 +89,11 @@ class Run extends BaseCommand {
     const scripts = AppScripts({ listeners })
     try {
       const result = await scripts.runDev([], runOptions)
+      try {
+        await runPackageScript('post-app-run')
+      } catch (err) {
+        // this is assumed to be a missing script error
+      }
       if (result) {
         if (process.env.AIO_LAUNCH_URL_PREFIX) {
           const launchUrl = process.env.AIO_LAUNCH_URL_PREFIX + result

--- a/src/commands/app/test.js
+++ b/src/commands/app/test.js
@@ -22,7 +22,7 @@ class Test extends BaseCommand {
     // this just runs package.json scripts.test, we could also check that this is in fact an aio app project
     const command = flags.e2e ? 'e2e' : 'test'
     try {
-      await appHelper.runPackageScript(command, process.cwd(), { silent: !flags.verbose })
+      await appHelper.runPackageScript(command, process.cwd())
     } catch (e) {
       return this.error(e.message, { exit: e.exitCode })
     }

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -72,7 +72,7 @@ describe('run', () => {
 
   test('build & deploy an App with no flags', async () => {
     mockScripts.deployUI.mockResolvedValue('https://example.com')
-    mockFS.existsSync.mockResolvedValue(true)
+    mockFS.existsSync.mockReturnValue(true)
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockScripts.deployActions).toHaveBeenCalledTimes(1)
@@ -137,7 +137,7 @@ describe('run', () => {
   test('build & deploy with --skip-actions', async () => {
     command.argv = ['--skip-actions']
     mockScripts.deployUI.mockResolvedValue('https://example.com')
-    mockFS.existsSync.mockResolvedValue(true)
+    mockFS.existsSync.mockReturnValue(true)
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockScripts.deployActions).toHaveBeenCalledTimes(0)
@@ -147,8 +147,22 @@ describe('run', () => {
     expect(mockOpen).toHaveBeenCalledWith('https://example.com')
   })
 
+  test('build & deploy with --skip-actions with no static folder', async () => {
+    command.argv = ['--skip-actions']
+    mockScripts.deployUI.mockResolvedValue('https://example.com')
+    mockFS.existsSync.mockReturnValue(false)
+    await command.run()
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployUI).toHaveBeenCalledTimes(0)
+    expect(mockScripts.buildActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.buildUI).toHaveBeenCalledTimes(0)
+    expect(mockOpen).toHaveBeenCalledTimes(0)
+  })
+
   test('--skip-deploy', async () => {
     command.argv = ['--skip-deploy']
+    mockFS.existsSync.mockReturnValue(true)
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockScripts.deployActions).toHaveBeenCalledTimes(0)

--- a/test/commands/app/test.test.js
+++ b/test/commands/app/test.test.js
@@ -87,7 +87,7 @@ describe('run', () => {
   const expectNoErrors = async (argv, testCmd) => {
     command.argv = argv
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith(testCmd, expect.any(String), { silent: true })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith(testCmd, expect.any(String))
   }
   const expectErrors = async (argv, errorCode) => {
     const error = new Error('fake error')
@@ -112,36 +112,36 @@ describe('run', () => {
   test('verbose flag', async () => {
     command.argv = ['--verbose']
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String))
   })
 
   test('-v flag', async () => {
     command.argv = ['-v']
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String))
   })
 
   test('--verbose --unit flag', async () => {
     command.argv = ['--verbose', '--unit']
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String))
   })
 
   test('-v -u flags', async () => {
     command.argv = ['-v', '-u']
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String))
   })
 
   test('--verbose --e2e flag', async () => {
     command.argv = ['--verbose', '--e2e']
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith('e2e', expect.any(String), { silent: false })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith('e2e', expect.any(String))
   })
 
   test('-v -e flags', async () => {
     command.argv = ['-v', '-e']
     await command.run()
-    expect(appHelper.runPackageScript).toHaveBeenCalledWith('e2e', expect.any(String), { silent: false })
+    expect(appHelper.runPackageScript).toHaveBeenCalledWith('e2e', expect.any(String))
   })
 })

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -63,46 +63,23 @@ describe('exports helper methods', () => {
     expect(appHelper.runPackageScript).toBeInstanceOf(Function)
   })
 
-  test('runPackageScript called without valid dir', async () => {
-    // throws error if dir dne => // fs.statSync(dir).isDirectory()
-    fs.statSync.mockReturnValue({
-      isDirectory: () => false
-    })
-    await expect(appHelper.runPackageScript('is-not-a-script', 'does-not-exist'))
-      .rejects.toThrow(/does-not-exist is not a directory/)
-  })
-
   test('runPackageScript missing package.json', async () => {
     // throws error if dir does not contain a package.json
-    fs.statSync.mockReturnValue({
-      isDirectory: () => true
-    })
-    fs.readdirSync.mockReturnValue([])
     await expect(appHelper.runPackageScript('is-not-a-script', 'does-not-exist'))
-      .rejects.toThrow(/does-not-exist does not contain a package.json file./)
+      .rejects.toThrow(/does-not-exist does not contain a package.json/)
   })
 
   test('runPackageScript success', async () => {
-    // succeeds if npm run-script returns success
-    fs.statSync.mockReturnValue({
-      isDirectory: () => true
-    })
-    fs.readdirSync.mockReturnValue(['package.json'])
-    fs.readJSONSync.mockReturnValue({ scripts: { test: 'some-value' } })
-
+    fs.readJSON.mockReturnValue({ scripts: { test: 'some-value' } })
     await appHelper.runPackageScript('test', '')
     expect(execa).toHaveBeenCalledWith('npm', ['run-script', 'test'], expect.any(Object))
   })
 
   test('runPackageScript success with silent option', async () => {
     // succeeds if npm run-script returns success
-    fs.statSync.mockReturnValue({
-      isDirectory: () => true
-    })
-    fs.readdirSync.mockReturnValue(['package.json'])
-    fs.readJSONSync.mockReturnValue({ scripts: { cmd: 'some-value' } })
+    fs.readJSON.mockReturnValue({ scripts: { cmd: 'some-value' } })
 
-    await appHelper.runPackageScript('cmd', '', { silent: true })
+    await appHelper.runPackageScript('cmd', '', ['--silent'])
     expect(execa).toHaveBeenCalledWith('npm', ['run-script', 'cmd', '--silent'], expect.any(Object))
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows developers to include their own build process parts.
Scripts in package.json of running project will be executed in the following order:

#### `aio app deploy` 
- pre-app-build
- post-app-build
- pre-app-deploy
- post-app-deploy

#### `aio app run`
- pre-app-run
- post-app-run

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
