### PR TITLE
Wrap errors to be printed correctly

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -19,7 +19,7 @@ const fs = require('fs-extra')
 const BaseCommand = require('../../BaseCommand')
 const AppScripts = require('@adobe/aio-app-scripts')
 const { flags } = require('@oclif/command')
-const { runPackageScript } = require('../../lib/app-helper')
+const { runPackageScript, wrapError } = require('../../lib/app-helper')
 
 class Deploy extends BaseCommand {
   async run () {
@@ -131,7 +131,7 @@ class Deploy extends BaseCommand {
       }
     } catch (error) {
       spinner.fail()
-      this.error(error)
+      this.error(wrapError(error))
     }
   }
 }

--- a/src/commands/app/logs.js
+++ b/src/commands/app/logs.js
@@ -16,6 +16,8 @@ const { flags } = require('@oclif/command')
 // const { cli } = require('cli-ux')
 const BaseCommand = require('../../BaseCommand')
 
+const { wrapError } = require('../../lib/app-helper')
+
 class Logs extends BaseCommand {
   async run () {
     const { flags } = this.parse(Logs)
@@ -31,7 +33,7 @@ class Logs extends BaseCommand {
       const foundLogs = await scripts.logs([], logOptions)
       return foundLogs
     } catch (error) {
-      this.error(error)
+      this.error(wrapError(error))
     }
   }
 }

--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -23,7 +23,7 @@ const coreConfig = require('@adobe/aio-lib-core-config')
 
 const BaseCommand = require('../../BaseCommand')
 const AppScripts = require('@adobe/aio-app-scripts')
-const { runPackageScript } = require('../../lib/app-helper')
+const { runPackageScript, wrapError } = require('../../lib/app-helper')
 
 const PRIVATE_KEY_PATH = 'dist/dev-keys/private.key'
 const PUB_CERT_PATH = 'dist/dev-keys/cert-pub.crt'
@@ -106,7 +106,7 @@ class Run extends BaseCommand {
         // fatality?
       }
     } catch (error) {
-      this.error(error)
+      this.error(wrapError(error))
     }
 
     const spinner = ora()
@@ -150,7 +150,7 @@ class Run extends BaseCommand {
       return result
     } catch (error) {
       spinner.fail()
-      this.error(error)
+      this.error(wrapError(error))
     }
   }
 }

--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -59,8 +59,8 @@ class Run extends BaseCommand {
             const Instance = CertCmd.load()
             await Instance.run([`--keyout=${PRIVATE_KEY_PATH}`, `--out=${PUB_CERT_PATH}`, '-n=DeveloperSelfSigned.cert'])
           } else {
-            // could not find the cert command
-            this.error('error while generating certificate - no certificate:generate command found')
+            // could not find the cert command, error is caught below
+            throw new Error('error while generating certificate - no certificate:generate command found')
           }
           // 3. store them globally in config
           const privateKey = (await fs.readFile(PRIVATE_KEY_PATH)).toString()

--- a/src/commands/app/undeploy.js
+++ b/src/commands/app/undeploy.js
@@ -18,6 +18,7 @@ const { flags } = require('@oclif/command')
 
 const BaseCommand = require('../../BaseCommand')
 const AppScripts = require('@adobe/aio-app-scripts')
+const { wrapError } = require('../../lib/app-helper')
 
 class Undeploy extends BaseCommand {
   async run () {
@@ -69,7 +70,7 @@ class Undeploy extends BaseCommand {
     } catch (error) {
       spinner.fail()
       // process.chdir(currDir)
-      this.error(error)
+      this.error(wrapError(error))
     }
   }
 }

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -51,9 +51,24 @@ async function runPackageScript (scriptName, dir, cmdArgs = []) {
   }
 }
 
+function wrapError (err) {
+  let message = 'Unknown error'
+
+  if (err) {
+    if (err instanceof Error) {
+      return err
+    }
+
+    message = err.stack || err.message || err
+  }
+
+  return new Error(message)
+}
+
 module.exports = {
   isNpmInstalled,
   isGitInstalled,
   installPackage,
-  runPackageScript
+  runPackageScript,
+  wrapError
 }

--- a/test/commands/app/logs.test.js
+++ b/test/commands/app/logs.test.js
@@ -52,7 +52,7 @@ describe('run', () => {
 
     mockScripts.logs.mockRejectedValue('error')
     await command.run()
-    expect(command.error).toHaveBeenCalledWith('error')
+    expect(command.error).toHaveBeenCalledWith(expect.objectContaining({ message: 'error' }))
   })
 
   test('when there are no logs, no flags', async () => {

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -89,4 +89,29 @@ describe('exports helper methods', () => {
     await expect(appHelper.runPackageScript('is-not-a-script', 'does-not-exist'))
       .rejects.toThrow(/does-not-exist/)
   })
+
+  test('wrapError returns an a Error in any case', async () => {
+    expect(appHelper.wrapError).toBeDefined()
+    expect(appHelper.wrapError).toBeInstanceOf(Function)
+
+    let error = appHelper.wrapError()
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toEqual('Unknown error')
+    expect(error.stack).toBeDefined()
+
+    error = appHelper.wrapError({ message: 'yolo' })
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toEqual('yolo')
+    expect(error.stack).toBeDefined()
+
+    error = appHelper.wrapError('yolo2')
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toEqual('yolo2')
+    expect(error.stack).toBeDefined()
+
+    error = appHelper.wrapError(new Error('yolo3'))
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toEqual('yolo3')
+    expect(error.stack).toBeDefined()
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In some cases error thrown by app scripts and internally by Parcel are not `instanceof Error`.
This creates a problem when calling `this.error(notInstanceOfErrorButObject)` which will log `[Object object]`.
This is a workaround to make sure that error messages and stack are always printed


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
