### PR TITLE
init --import: enrich jwt config with ims_org_id

### DIFF
--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -396,6 +396,19 @@ async function importConfigJson (configFileLocation, destinationFolder = process
 
   checkRules(config)
 
+  // enrich credentials.jwt with ims org
+  if (typeof credentials.jwt === 'object' && !credentials.jwt.ims_org_id) {
+    // not checking for config.project && config.project.org as part of required rules
+    if (config.project.org.ims_org_id) {
+      debug('adding ims_org_id to $ims.jwt config')
+      credentials.jwt.ims_org_id = config.project.org.ims_org_id
+    } else {
+      const warning = 'missing project.org.ims_org_id, which is needed for ims jwt config'
+      debug('warn:', warning)
+      console.warn(warning)
+    }
+  }
+
   await writeEnv({ runtime, $ims: credentials }, destinationFolder, flags)
 
   // remove the credentials

--- a/test/__fixtures__/config.6.orgid.aio
+++ b/test/__fixtures__/config.6.orgid.aio
@@ -1,0 +1,13 @@
+{
+  "id": "this is some data",
+  "name": "myname",
+  "app_url": "https://my.app.url/foo/bar",
+  "action_url": "https://my.action.url/foo/bar",
+  "project": {
+    "name": "projectname",
+    "org": {
+      "name": "orgname",
+      "ims_org_id": "abcde@AdobeOrg"
+    }
+  }
+}

--- a/test/__fixtures__/config.6.orgid.env
+++ b/test/__fixtures__/config.6.orgid.env
@@ -1,0 +1,12 @@
+AIO_runtime_namespace=my-namespace
+AIO_runtime_credentials=my-runtime-credentials
+AIO_$ims_apikey_client__id=83723cc8e25e455fb5db1ad12cbf16e9
+AIO_$ims_oauth2_client__id=83723cc8e25e455fb5db1ad12cbf16e9
+AIO_$ims_oauth2_client__secret=XXXXXX
+AIO_$ims_oauth2_redirect__uri=https://www.adobe.com
+AIO_$ims_jwt_client__id=568430a7b22e4a1f993d03ed8283bb26
+AIO_$ims_jwt_client__secret=XXXXX
+AIO_$ims_jwt_techacct=E03445FF5D81F8EA0A494034@techacct.adobe.com
+AIO_$ims_jwt_meta__scopes=["ent_partners_sdk"]
+AIO_$ims_jwt_private__key=["-----BEGIN PRIVATE KEY-----","XXXX...XXX","-----END PRIVATE KEY-----"]
+AIO_$ims_jwt_ims__org__id=abcde@AdobeOrg

--- a/test/__fixtures__/config.6.orgid.hjson
+++ b/test/__fixtures__/config.6.orgid.hjson
@@ -1,0 +1,39 @@
+{
+  // This is a hjson config file that is entirely valid
+  "id": "this is some data",
+  "name": "myname",
+  "app_url": "https://my.app.url/foo/bar",
+  "action_url": "https://my.action.url/foo/bar",
+  "project": {
+    "name": "projectname",
+    "org": {
+        "name": "orgname",
+        "ims_org_id": "abcde@AdobeOrg"
+    }
+  },
+  "runtime": {
+    "namespace": "my-namespace",
+    "credentials": "my-runtime-credentials"
+  },
+  "credentials": {
+    "apikey": {
+      "client_id": "83723cc8e25e455fb5db1ad12cbf16e9"
+    },
+    "oauth2": {
+      "client_id": "83723cc8e25e455fb5db1ad12cbf16e9",
+      "client_secret": "XXXXXX",
+      "redirect_uri": "https://www.adobe.com"
+    },
+    "jwt": {
+      "client_id": "568430a7b22e4a1f993d03ed8283bb26",
+      "client_secret": "XXXXX",
+      "techacct": "E03445FF5D81F8EA0A494034@techacct.adobe.com",
+      "meta_scopes": ["ent_partners_sdk"],
+      "private_key": [
+        "-----BEGIN PRIVATE KEY-----",
+        "XXXX...XXX",
+        "-----END PRIVATE KEY-----"
+      ]
+    }
+  }
+}

--- a/test/__fixtures__/config.6.orgid.no.jwt.aio
+++ b/test/__fixtures__/config.6.orgid.no.jwt.aio
@@ -1,0 +1,13 @@
+{
+  "id": "this is some data",
+  "name": "myname",
+  "app_url": "https://my.app.url/foo/bar",
+  "action_url": "https://my.action.url/foo/bar",
+  "project": {
+    "name": "projectname",
+    "org": {
+      "name": "orgname",
+      "ims_org_id": "abcde@AdobeOrg"
+    }
+  }
+}

--- a/test/__fixtures__/config.6.orgid.no.jwt.env
+++ b/test/__fixtures__/config.6.orgid.no.jwt.env
@@ -1,0 +1,6 @@
+AIO_runtime_namespace=my-namespace
+AIO_runtime_credentials=my-runtime-credentials
+AIO_$ims_apikey_client__id=83723cc8e25e455fb5db1ad12cbf16e9
+AIO_$ims_oauth2_client__id=83723cc8e25e455fb5db1ad12cbf16e9
+AIO_$ims_oauth2_client__secret=XXXXXX
+AIO_$ims_oauth2_redirect__uri=https://www.adobe.com

--- a/test/__fixtures__/config.6.orgid.no.jwt.hjson
+++ b/test/__fixtures__/config.6.orgid.no.jwt.hjson
@@ -1,0 +1,28 @@
+{
+  // This is a hjson config file that is entirely valid
+  "id": "this is some data",
+  "name": "myname",
+  "app_url": "https://my.app.url/foo/bar",
+  "action_url": "https://my.action.url/foo/bar",
+  "project": {
+    "name": "projectname",
+    "org": {
+        "name": "orgname",
+        "ims_org_id": "abcde@AdobeOrg"
+    }
+  },
+  "runtime": {
+    "namespace": "my-namespace",
+    "credentials": "my-runtime-credentials"
+  },
+  "credentials": {
+    "apikey": {
+      "client_id": "83723cc8e25e455fb5db1ad12cbf16e9"
+    },
+    "oauth2": {
+      "client_id": "83723cc8e25e455fb5db1ad12cbf16e9",
+      "client_secret": "XXXXXX",
+      "redirect_uri": "https://www.adobe.com"
+    }
+  }
+}

--- a/test/commands/lib/import.test.js
+++ b/test/commands/lib/import.test.js
@@ -243,3 +243,38 @@ test('enforce alphanumeric content rule - credentials.oauth2.redirect_uri set an
 
   await expect(fs.writeFile).toHaveBeenCalledTimes(0)
 })
+
+test('enrich $ims.jwt with project.org.ims_org_id', async () => {
+  const workingFolder = 'my-working-folder'
+  const aioPath = path.join(workingFolder, '.aio')
+  const envPath = path.join(workingFolder, '.env')
+  const configPath = '/some/config/path'
+
+  fs.readFileSync.mockReturnValueOnce(fixtureFile('config.6.orgid.hjson'))
+  await importConfigJson(configPath, workingFolder, { overwrite: true })
+  await expect(fs.writeFile.mock.calls[0][0]).toMatch(envPath)
+  await expect(fs.writeFile.mock.calls[0][1]).toMatchFixture('config.6.orgid.env')
+  await expect(fs.writeFile.mock.calls[0][2]).toMatchObject({ flag: 'w' })
+  await expect(fs.writeFile.mock.calls[1][0]).toMatch(aioPath)
+  await expect(fs.writeFile.mock.calls[1][1]).toMatchFixture('config.6.orgid.aio')
+  await expect(fs.writeFile.mock.calls[1][2]).toMatchObject({ flag: 'w' })
+
+  expect(fs.writeFile).toHaveBeenCalledTimes(2)
+})
+
+test('do not enrich $ims.jwt with ims_org_id if no jwt credentials defined ', async () => {
+  const workingFolder = 'my-working-folder'
+  const aioPath = path.join(workingFolder, '.aio')
+  const envPath = path.join(workingFolder, '.env')
+  const configPath = '/some/config/path'
+
+  fs.readFileSync.mockReturnValueOnce(fixtureFile('config.6.orgid.no.jwt.hjson'))
+  await importConfigJson(configPath, workingFolder, { overwrite: true })
+  await expect(fs.writeFile.mock.calls[0][0]).toMatch(envPath)
+  await expect(fs.writeFile.mock.calls[0][1]).toMatchFixture('config.6.orgid.no.jwt.env')
+  await expect(fs.writeFile.mock.calls[0][2]).toMatchObject({ flag: 'w' })
+  await expect(fs.writeFile.mock.calls[1][0]).toMatch(aioPath)
+  await expect(fs.writeFile.mock.calls[1][1]).toMatchFixture('config.6.orgid.no.jwt.aio')
+  await expect(fs.writeFile.mock.calls[1][2]).toMatchObject({ flag: 'w' })
+  expect(fs.writeFile).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When importing the config, this pr ensures `ims_org_id` is copied to the `$ims.jwt` config.
The goal is to be compatible with required jwt configuration in https://github.com/adobe/aio-lib-core-ims-jwt/blob/master/src/ims-jwt.js#L21

<!--- Describe your changes in detail -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
