### PR TITLE
Use generator-aio-console in `app init`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@adobe/aio-app-scripts": "^0.15.0",
     "@adobe/aio-lib-core-config": ">=1.2.8",
     "@adobe/aio-lib-core-logging": "^1.1.0",
+    "@adobe/aio-lib-ims": "^2.0.1",
     "@adobe/generator-aio-app": "^0.7.2",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.9",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@adobe/aio-lib-core-logging": "^1.1.0",
     "@adobe/aio-lib-ims": "^2.0.1",
     "@adobe/generator-aio-app": "^0.7.2",
+    "@adobe/generator-aio-console": "^1.0.0",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.9",
     "ajv": "^6.12.2",

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -38,7 +38,7 @@ class InitCommand extends BaseCommand {
     let projectName = path.basename(process.cwd())
     let services = 'AdobeTargetSDK,AdobeAnalyticsSDK,CampaignSDK,McDataServicesSdk,AudienceManagerCustomerSDK' // todo fetch those from console when no --import
 
-    if (!flags.import) {
+    if (!(flags.import || flags.yes)) {
       const accessToken = await getToken(CLI)
       const { env: imsEnv = 'prod' } = await context.getCli()
 

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -16,7 +16,7 @@ const fs = require('fs-extra')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:init', { provider: 'debug' })
 const { flags } = require('@oclif/command')
 const { validateConfig, importConfigJson, loadConfigFile, writeAio } = require('../../lib/import')
-const { getToken } = require('@adobe/aio-lib-ims')
+const { getToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
 const chalk = require('chalk')
 
@@ -53,11 +53,13 @@ class InitCommand extends BaseCommand {
 
     if (!flags.import) {
       const accessToken = await getToken(CLI)
+      const imsEnv = (await context.getCli()).env
 
       try {
         env.register(require.resolve('@adobe/generator-aio-console'), 'gen-console')
         res = await env.run('gen-console', {
-          'access-token': accessToken
+          'access-token': accessToken,
+          'ims-env': imsEnv
         })
         // trigger import
         flags.import = 'console.json'

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -40,7 +40,7 @@ class InitCommand extends BaseCommand {
 
     if (!(flags.import || flags.yes)) {
       const accessToken = await getToken(CLI)
-      const { env: imsEnv = 'prod' } = await context.getCli()
+      const { env: imsEnv = 'prod' } = await context.getCli() || {}
 
       try {
         const generatedFile = 'console.json'

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -53,7 +53,7 @@ class InitCommand extends BaseCommand {
         // trigger import
         flags.import = generatedFile
       } catch (e) {
-        console.log(chalk.red(e.message))
+        this.log(chalk.red(e.message))
       }
       this.log()
     }

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -18,6 +18,7 @@ const { flags } = require('@oclif/command')
 const { validateConfig, importConfigJson, loadConfigFile, writeAio } = require('../../lib/import')
 const { getToken } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
+const chalk = require('chalk')
 
 class InitCommand extends BaseCommand {
   async run () {
@@ -53,13 +54,17 @@ class InitCommand extends BaseCommand {
     if (!flags.import) {
       const accessToken = await getToken(CLI)
 
-      env.register(require.resolve('@adobe/generator-aio-console'), 'gen-console')
-      res = await env.run('gen-console', {
-        'access-token': accessToken
-      })
-
-      // trigger import
-      flags.import = 'console.json'
+      try {
+        env.register(require.resolve('@adobe/generator-aio-console'), 'gen-console')
+        res = await env.run('gen-console', {
+          'access-token': accessToken
+        })
+        // trigger import
+        flags.import = 'console.json'
+      } catch (e) {
+        console.log(chalk.red(e.message))
+      }
+      this.log()
     }
 
     // call code generator

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -53,16 +53,18 @@ class InitCommand extends BaseCommand {
 
     if (!flags.import) {
       const accessToken = await getToken(CLI)
-      const imsEnv = (await context.getCli()).env
+      const imsEnv = (await context.getCli()).env || 'prod'
 
       try {
+        const generatedFile = 'console.json'
         env.register(require.resolve('@adobe/generator-aio-console'), 'gen-console')
         res = await env.run('gen-console', {
+          'destination-file': generatedFile,
           'access-token': accessToken,
           'ims-env': imsEnv
         })
         // trigger import
-        flags.import = 'console.json'
+        flags.import = generatedFile
       } catch (e) {
         console.log(chalk.red(e.message))
       }

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -157,16 +157,18 @@ describe('run', () => {
   })
 
   test('some-path, --yes', async () => {
-    const project = mockValidConfig()
-    await TheCommand.run(['some-path', '--yes'])
+    mockValidConfig()
+    const appFolder = 'some-path'
+    await TheCommand.run([appFolder, '--yes'])
 
+    // gen-console is skipped
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(2)
-    const genApp = mockRegister.mock.calls[1][1]
-    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    const genApp = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genApp, {
       'skip-prompt': true,
       'skip-install': false,
-      'project-name': project.name,
+      'project-name': appFolder,
       'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).toHaveBeenCalledWith(expect.stringContaining('some-path'))
@@ -174,16 +176,18 @@ describe('run', () => {
   })
 
   test('some-path, --yes --skip-install', async () => {
-    const project = mockValidConfig()
-    await TheCommand.run(['some-path', '--yes', '--skip-install'])
+    mockValidConfig()
+    const appFolder = 'some-path'
+    await TheCommand.run([appFolder, '--yes', '--skip-install'])
 
+    // gen-console is skipped
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(2)
-    const genApp = mockRegister.mock.calls[1][1]
-    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    const genApp = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genApp, {
       'skip-prompt': true,
       'skip-install': true,
-      'project-name': project.name,
+      'project-name': appFolder,
       'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).toHaveBeenCalledWith(expect.stringContaining('some-path'))
@@ -194,10 +198,11 @@ describe('run', () => {
     const project = mockValidConfig()
     await TheCommand.run(['--yes'])
 
+    // gen-console is skipped
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(2)
-    const genApp = mockRegister.mock.calls[1][1]
-    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    const genApp = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genApp, {
       'skip-prompt': true,
       'skip-install': false,
       'project-name': project.name,
@@ -211,10 +216,11 @@ describe('run', () => {
     const project = mockValidConfig()
     await TheCommand.run(['--yes', '--skip-install'])
 
+    // gen-console is skipped
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(2)
-    const genApp = mockRegister.mock.calls[1][1]
-    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    const genApp = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genApp, {
       'skip-prompt': true,
       'skip-install': true,
       'project-name': project.name,
@@ -230,6 +236,12 @@ describe('run', () => {
 
     expect(yeoman.createEnv).toHaveBeenCalled()
     expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genConsole = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genConsole, {
+      'access-token': mockAccessToken,
+      'destination-file': 'console.json',
+      'ims-env': 'prod'
+    })
     const genApp = mockRegister.mock.calls[1][1]
     expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': false,
@@ -250,6 +262,12 @@ describe('run', () => {
 
     expect(yeoman.createEnv).toHaveBeenCalled()
     expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genConsole = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genConsole, {
+      'access-token': mockAccessToken,
+      'destination-file': 'console.json',
+      'ims-env': 'prod'
+    })
     const genApp = mockRegister.mock.calls[1][1]
     expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': false,
@@ -271,6 +289,12 @@ describe('run', () => {
 
     expect(yeoman.createEnv).toHaveBeenCalled()
     expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genConsole = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genConsole, {
+      'access-token': mockAccessToken,
+      'destination-file': 'console.json',
+      'ims-env': 'prod'
+    })
     const genApp = mockRegister.mock.calls[1][1]
     expect(mockRun).toHaveBeenCalledWith(genApp, {
       'skip-prompt': false,

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -127,7 +127,7 @@ function mockValidConfig ({ name = 'lifeisgood', services = fullServicesJson } =
 /** @private */
 function mockInvalidConfig () {
   const foo = {
-    bar: 'lifeisjustok'
+    bar: 'lifeismeh'
   }
 
   importLib.loadConfigFile.mockReturnValue({
@@ -261,7 +261,9 @@ describe('run', () => {
 
   test('no imports should write aio config', async () => {
     // the only way we write defaults if gen-console threw an error
+    mockRun.mockImplementationOnce(() => { throw new Error('some error') })
 
+    const project = mockValidConfig()
     await TheCommand.run([])
 
     expect(fs.ensureDirSync).not.toHaveBeenCalled()
@@ -273,11 +275,11 @@ describe('run', () => {
     expect(mockRun).toHaveBeenCalledWith(genApp, {
       'skip-prompt': false,
       'skip-install': false,
-      'project-name': 'lifeisgood',
+      'project-name': project.name,
       'adobe-services': getFullServicesList()
     })
     expect(importLib.writeAio).toHaveBeenCalledWith(
-      { services: [{ code: 'AdobeTargetSDK' }, { code: 'AdobeAnalyticsSDK' }, { code: 'CampaignSDK' }, { code: 'McDataServicesSdk' }, { code: 'AudienceManagerCustomerSDK' }] },
+      { services: fullServicesJson },
       process.cwd(),
       { interactive: false, merge: true }
     )

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -18,6 +18,16 @@ jest.mock('../../../src/lib/import')
 
 jest.mock('fs-extra')
 
+const mockAccessToken = 'some-access-token'
+jest.mock('@adobe/aio-lib-ims', () => {
+  return {
+    context: {
+      getCli: () => ({})
+    },
+    getToken: () => mockAccessToken
+  }
+})
+
 jest.mock('yeoman-environment')
 const yeoman = require('yeoman-environment')
 
@@ -80,14 +90,62 @@ describe('template module cannot be registered', () => {
   })
 })
 
-const fullServicesList = 'AdobeTargetSDK,AdobeAnalyticsSDK,CampaignSDK,McDataServicesSdk,AudienceManagerCustomerSDK'
+const fullServicesJson = [
+  { code: 'AdobeTargetSDK' },
+  { code: 'AdobeAnalyticsSDK' },
+  { code: 'CampaignSDK' },
+  { code: 'McDataServicesSdk' },
+  { code: 'AudienceManagerCustomerSDK' }
+]
+
+/** @private */
+function getFullServicesList () {
+  return fullServicesJson.map(s => s.code).join(',')
+}
+
+/** @private */
+function mockValidConfig ({ name = 'lifeisgood', services = fullServicesJson } = {}) {
+  const project = {
+    name,
+    workspace: {
+      details: {
+        services
+      }
+    }
+  }
+
+  importLib.loadConfigFile.mockReturnValue({
+    values: { project }
+  })
+  importLib.validateConfig.mockReturnValue({
+    valid: true
+  })
+
+  return project
+}
+
+/** @private */
+function mockInvalidConfig () {
+  const foo = {
+    bar: 'lifeisjustok'
+  }
+
+  importLib.loadConfigFile.mockReturnValue({
+    values: { foo }
+  })
+  importLib.validateConfig.mockReturnValue({
+    valid: false
+  })
+
+  return foo
+}
 
 describe('run', () => {
   const spyChdir = jest.spyOn(process, 'chdir')
   const spyCwd = jest.spyOn(process, 'cwd')
   let fakeCwd
   beforeEach(() => {
-    fakeCwd = 'yolo'
+    fakeCwd = 'lifeisgood'
     spyChdir.mockClear()
     spyCwd.mockClear()
     spyChdir.mockImplementation(dir => { fakeCwd = dir })
@@ -99,116 +157,124 @@ describe('run', () => {
   })
 
   test('some-path, --yes', async () => {
+    const project = mockValidConfig()
     await TheCommand.run(['some-path', '--yes'])
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': true,
       'skip-install': false,
-      'project-name': 'some-path',
-      'adobe-services': fullServicesList
+      'project-name': project.name,
+      'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).toHaveBeenCalledWith(expect.stringContaining('some-path'))
     expect(spyChdir).toHaveBeenCalledWith(expect.stringContaining('some-path'))
   })
 
   test('some-path, --yes --skip-install', async () => {
+    const project = mockValidConfig()
     await TheCommand.run(['some-path', '--yes', '--skip-install'])
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': true,
       'skip-install': true,
-      'project-name': 'some-path',
-      'adobe-services': fullServicesList
+      'project-name': project.name,
+      'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).toHaveBeenCalledWith(expect.stringContaining('some-path'))
     expect(spyChdir).toHaveBeenCalledWith(expect.stringContaining('some-path'))
   })
 
   test('no-path, --yes', async () => {
+    const project = mockValidConfig()
     await TheCommand.run(['--yes'])
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': true,
       'skip-install': false,
-      'project-name': 'yolo',
-      'adobe-services': fullServicesList
+      'project-name': project.name,
+      'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).not.toHaveBeenCalled()
     expect(spyChdir).not.toHaveBeenCalled()
   })
 
   test('no-path, --yes --skip-install', async () => {
+    const project = mockValidConfig()
     await TheCommand.run(['--yes', '--skip-install'])
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': true,
       'skip-install': true,
-      'project-name': 'yolo',
-      'adobe-services': fullServicesList
+      'project-name': project.name,
+      'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).not.toHaveBeenCalled()
     expect(spyChdir).not.toHaveBeenCalled()
   })
 
   test('no-path, --skip-install', async () => {
+    const project = mockValidConfig()
     await TheCommand.run(['--skip-install'])
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': false,
       'skip-install': true,
-      'project-name': 'yolo',
-      'adobe-services': fullServicesList
+      'project-name': project.name,
+      'adobe-services': getFullServicesList()
     })
     expect(fs.ensureDirSync).not.toHaveBeenCalled()
     expect(spyChdir).not.toHaveBeenCalled()
   })
 
   test('no-path', async () => {
+    const project = mockValidConfig()
     await TheCommand.run([])
 
     expect(fs.ensureDirSync).not.toHaveBeenCalled()
     expect(spyChdir).not.toHaveBeenCalled()
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenNthCalledWith(2, genApp, {
       'skip-prompt': false,
       'skip-install': false,
-      'project-name': 'yolo',
-      'adobe-services': fullServicesList
+      'project-name': project.name,
+      'adobe-services': getFullServicesList()
     })
   })
 
   test('no imports should write aio config', async () => {
+    // the only way we write defaults if gen-console threw an error
+
     await TheCommand.run([])
 
     expect(fs.ensureDirSync).not.toHaveBeenCalled()
     expect(spyChdir).not.toHaveBeenCalled()
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    const genApp = mockRegister.mock.calls[1][1]
+    expect(mockRun).toHaveBeenCalledWith(genApp, {
       'skip-prompt': false,
       'skip-install': false,
-      'project-name': 'yolo',
-      'adobe-services': fullServicesList
+      'project-name': 'lifeisgood',
+      'adobe-services': getFullServicesList()
     })
     expect(importLib.writeAio).toHaveBeenCalledWith(
       { services: [{ code: 'AdobeTargetSDK' }, { code: 'AdobeAnalyticsSDK' }, { code: 'CampaignSDK' }, { code: 'McDataServicesSdk' }, { code: 'AudienceManagerCustomerSDK' }] },
@@ -218,39 +284,15 @@ describe('run', () => {
   })
 
   test('no-path --import file=invalid config', async () => {
-    // mock config file
-    importLib.loadConfigFile.mockReturnValue({
-      values: {
-        foo: {
-          bar: 'yolo'
-        }
-      }
-    })
-    importLib.validateConfig.mockReturnValue({
-      valid: false
-    })
-
+    mockInvalidConfig()
     await expect(TheCommand.run(['--import', 'config.json'])).rejects.toThrow('Missing or invalid keys in config:')
   })
 
-  test('no-path --import file={name: yolo, services:AdobeTargetSDK,CampaignSDK}', async () => {
-    // mock config file
-    importLib.loadConfigFile.mockReturnValue({
-      values: {
-        project: {
-          name: 'yolo',
-          workspace: {
-            details: {
-              services: [{ code: 'AdobeTargetSDK' }, { code: 'CampaignSDK' }]
-            }
-          }
-        }
-      }
+  test('no-path --import file={name: lifeisgood, services:AdobeTargetSDK,CampaignSDK}', async () => {
+    const project = mockValidConfig({
+      name: 'lifeisgood',
+      services: [{ code: 'AdobeTargetSDK' }, { code: 'CampaignSDK' }]
     })
-    importLib.validateConfig.mockReturnValue({
-      valid: true
-    })
-
     await TheCommand.run(['--import', 'config.json'])
 
     // no args.path
@@ -259,33 +301,21 @@ describe('run', () => {
 
     expect(yeoman.createEnv).toHaveBeenCalled()
     expect(mockRegister).toHaveBeenCalledTimes(1)
-    const genName = mockRegister.mock.calls[0][1]
-    expect(mockRun).toHaveBeenCalledWith(genName, {
+    const genApp = mockRegister.mock.calls[0][1]
+    expect(mockRun).toHaveBeenNthCalledWith(1, genApp, {
       'skip-prompt': false,
       'skip-install': false,
-      'project-name': 'yolo',
+      'project-name': project.name,
       'adobe-services': 'AdobeTargetSDK,CampaignSDK'
     })
 
     expect(importLib.importConfigJson).toHaveBeenCalledWith('config.json', process.cwd(), { interactive: false, merge: true })
   })
 
-  test('no-path --yes --import file={name: yolo, services:AdobeTargetSDK,CampaignSDK}', async () => {
-    // mock config file
-    importLib.loadConfigFile.mockReturnValue({
-      values: {
-        project: {
-          name: 'yolo',
-          workspace: {
-            details: {
-              services: [{ code: 'AdobeTargetSDK' }, { code: 'CampaignSDK' }]
-            }
-          }
-        }
-      }
-    })
-    importLib.validateConfig.mockReturnValue({
-      valid: true
+  test('no-path --yes --import file={name: lifeisgood, services:AdobeTargetSDK,CampaignSDK}', async () => {
+    const project = mockValidConfig({
+      name: 'lifeisgood',
+      services: [{ code: 'AdobeTargetSDK' }, { code: 'CampaignSDK' }]
     })
     await TheCommand.run(['--yes', '--import', 'config.json'])
 
@@ -299,30 +329,15 @@ describe('run', () => {
     expect(mockRun).toHaveBeenCalledWith(genName, {
       'skip-prompt': true,
       'skip-install': false,
-      'project-name': 'yolo',
+      'project-name': project.name,
       'adobe-services': 'AdobeTargetSDK,CampaignSDK'
     })
 
     expect(importLib.importConfigJson).toHaveBeenCalledWith('config.json', process.cwd(), { interactive: false, merge: true })
   })
 
-  test('some-path --import file={name: yolo, services:undefined}', async () => {
-    // mock config file
-    importLib.loadConfigFile.mockReturnValue({
-      values: {
-        project: {
-          name: 'yolo',
-          workspace: {
-            details: {
-              services: []
-            }
-          }
-        }
-      }
-    })
-    importLib.validateConfig.mockReturnValue({
-      valid: true
-    })
+  test('some-path --import file={name: lifeisgood, services:undefined}', async () => {
+    const project = mockValidConfig({ name: 'lifeisgood', services: [] })
     await TheCommand.run(['some-path', '--import', 'config.json'])
 
     // no args.path
@@ -335,7 +350,7 @@ describe('run', () => {
     expect(mockRun).toHaveBeenCalledWith(genName, {
       'skip-prompt': false,
       'skip-install': false,
-      'project-name': 'yolo',
+      'project-name': project.name,
       'adobe-services': ''
     })
 


### PR DESCRIPTION
## Description

Addition of the console generator in app init. This requires user interaction in selecting the user's org, then project, then workspace -- to download the project config. The project config will then be imported and used.

To skip this user interaction, use the `--yes` or `--import` flag.

## How Has This Been Tested?

npm test
aio app init (should go through gen-console)
aio app init -y (skips gen-console)
aio app init --import config_file (skips gen_console)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
