### PR TITLE
fix: `aio app init` and `aio app use` failing if not logged in before (Error: IMS context '$cli' is not configured)

### DIFF
--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -16,8 +16,7 @@ const fs = require('fs-extra')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:init', { provider: 'debug' })
 const { flags } = require('@oclif/command')
 const { validateConfig, importConfigJson, loadConfigFile, writeAio } = require('../../lib/import')
-const { getToken, context } = require('@adobe/aio-lib-ims')
-const { CLI } = require('@adobe/aio-lib-ims/src/context')
+const { getCliInfo } = require('../../lib/app-helper')
 const chalk = require('chalk')
 
 class InitCommand extends BaseCommand {
@@ -39,8 +38,7 @@ class InitCommand extends BaseCommand {
     let services = 'AdobeTargetSDK,AdobeAnalyticsSDK,CampaignSDK,McDataServicesSdk,AudienceManagerCustomerSDK' // todo fetch those from console when no --import
 
     if (!(flags.import || flags.yes)) {
-      const accessToken = await getToken(CLI)
-      const { env: imsEnv = 'prod' } = await context.getCli() || {}
+      const { accessToken, env: imsEnv } = await getCliInfo()
 
       try {
         const generatedFile = 'console.json'

--- a/src/commands/app/use.js
+++ b/src/commands/app/use.js
@@ -15,9 +15,8 @@ const { flags } = require('@oclif/command')
 const inquirer = require('inquirer')
 const config = require('@adobe/aio-lib-core-config')
 const { EOL } = require('os')
-const { getToken, context } = require('@adobe/aio-lib-ims')
-const { CLI } = require('@adobe/aio-lib-ims/src/context')
 const yeoman = require('yeoman-environment')
+const { getCliInfo } = require('../../lib/app-helper')
 
 class Use extends BaseCommand {
   async consoleConfigString (consoleConfig) {
@@ -46,8 +45,7 @@ class Use extends BaseCommand {
 
       if (confirm.res) {
         const { org, project, workspace } = consoleConfig
-        const accessToken = await getToken(CLI)
-        const { env: imsEnv = 'prod' } = await context.getCli() || {}
+        const { accessToken, env: imsEnv } = await getCliInfo()
 
         const generatedFile = 'console.json'
         const env = yeoman.createEnv()

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -14,6 +14,8 @@ const fs = require('fs-extra')
 const path = require('path')
 const which = require('which')
 const debug = require('debug')('aio-cli-plugin-app:app-helper')
+const { getToken, context } = require('@adobe/aio-lib-ims')
+const { CLI } = require('@adobe/aio-lib-ims/src/context')
 
 /** @private */
 function isNpmInstalled () {
@@ -70,10 +72,22 @@ function wrapError (err) {
   return new Error(message)
 }
 
+/** @private */
+async function getCliInfo () {
+  const { env = 'prod' } = await context.getCli() || {}
+  await context.setCli({ '$cli.bare-output': true }, false) // set this globally
+
+  debug('Retrieving CLI Token')
+  const accessToken = await getToken(CLI)
+
+  return { accessToken, env }
+}
+
 module.exports = {
   isNpmInstalled,
   isGitInstalled,
   installPackage,
   runPackageScript,
-  wrapError
+  wrapError,
+  getCliInfo
 }

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -20,10 +20,12 @@ jest.mock('fs-extra')
 
 const mockAccessToken = 'some-access-token'
 const mockGetCli = jest.fn()
+const mockSetCli = jest.fn()
 jest.mock('@adobe/aio-lib-ims', () => {
   return {
     context: {
-      getCli: () => mockGetCli()
+      getCli: () => mockGetCli(),
+      setCli: () => mockSetCli()
     },
     getToken: () => mockAccessToken
   }

--- a/test/commands/app/use.test.js
+++ b/test/commands/app/use.test.js
@@ -20,10 +20,12 @@ const mockConfig = require('@adobe/aio-lib-core-config')
 
 const mockAccessToken = 'some-access-token'
 const mockGetCli = jest.fn()
+const mockSetCli = jest.fn()
 jest.mock('@adobe/aio-lib-ims', () => {
   return {
     context: {
-      getCli: () => mockGetCli()
+      getCli: () => mockGetCli(),
+      setCli: () => mockSetCli()
     },
     getToken: () => mockAccessToken
   }


### PR DESCRIPTION
Fixes #228 

## How Has This Been Tested?
```
npm test
aio config rm \$ims && aio app init
aio config rm \$ims && aio app use
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
