### PR TITLE
feat: keep a reference to the credentials in the config

### DIFF
--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -522,6 +522,37 @@ function transformCredentials (credentials, imsOrgId) {
 }
 
 /**
+ * Trim the credentials array to only keep a reference to each integration credential.
+ * Replace spaces in the name with _ and lowercase the name
+ *
+ * @example
+ * from:
+ * [{
+ *   "id": "17561142",
+ *   "name": "Project Foo",
+ *   "integration_type": "oauthweb",
+ *   "oauth2": {
+ *       "client_id": "XYXYXYXYXYXYXYXYX",
+ *       "client_secret": "XYXYXYXYZZZZZZ",
+ *       "redirect_uri": "https://test123"
+ *   }
+ * }]
+ * to:
+ * [{
+ *   "id": "17561142",
+ *   "name": "project_foo",
+ *   "integration_type": "oauthweb"
+ * }]
+ *
+ * @param {Array} credentials array from Downloadable File Format
+ * @returns {object} an array holding only the references to the credentials
+ * @private
+ */
+function credentialsReferences (credentials) {
+  return credentials.map(c => ({ id: c.id, name: c.name.replace(/ /gi, '_').toLowerCase(), integration_type: c.integration_type }))
+}
+
+/**
  * Import a downloadable config and write to the appropriate .env (credentials) and .aio (non-credentials) files.
  *
  * @param {string} configFileLocation the path to the config file to import
@@ -549,7 +580,8 @@ async function importConfigJson (configFileLocation, destinationFolder = process
 
   // remove the credentials
   delete config.project.workspace.details.runtime
-  delete config.project.workspace.details.credentials
+  // keep only a reference to the credentials in the aio config (hiding secrets)
+  config.project.workspace.details.credentials = credentialsReferences(config.project.workspace.details.credentials)
 
   // write to the console config (for the `aio console` commands)
   await writeConsoleConfig(config)

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -549,7 +549,7 @@ function transformCredentials (credentials, imsOrgId) {
  * @private
  */
 function credentialsReferences (credentials) {
-  return credentials.map(c => ({ id: c.id, name: c.name.replace(/ /gi, '_').toLowerCase(), integration_type: c.integration_type }))
+  return credentials.map(c => ({ id: c.id, name: c.name.replace(/ /gi, '_'), integration_type: c.integration_type }))
 }
 
 /**

--- a/test/__fixtures__/config.orgid.aio
+++ b/test/__fixtures__/config.orgid.aio
@@ -17,6 +17,18 @@
       "action_url": "https://ABCD-TestProject-TestWorkspace.adobeioruntime.net",
       "app_url": "https://ABCD-TestProject-TestWorkspace.adobestatic.net",
       "details": {
+        "credentials": [
+          {
+            "id": "17606512",
+            "name": "projectb",
+            "integration_type": "service"
+          },
+          {
+            "id": "17950",
+            "name": "newtestintegration8",
+            "integration_type": "oauthandroid"
+          }
+        ],
         "services": []
       }
     }

--- a/test/__fixtures__/config.orgid.aio
+++ b/test/__fixtures__/config.orgid.aio
@@ -20,12 +20,12 @@
         "credentials": [
           {
             "id": "17606512",
-            "name": "projectb",
+            "name": "ProjectB",
             "integration_type": "service"
           },
           {
             "id": "17950",
-            "name": "newtestintegration8",
+            "name": "NewTestIntegration8",
             "integration_type": "oauthandroid"
           }
         ],

--- a/test/__fixtures__/config.orgid.no.jwt.aio
+++ b/test/__fixtures__/config.orgid.no.jwt.aio
@@ -17,6 +17,13 @@
       "action_url": "https://ABCD-TestProject-TestWorkspace.adobeioruntime.net",
       "app_url": "https://ABCD-TestProject-TestWorkspace.adobestatic.net",
       "details": {
+        "credentials": [
+          {
+            "id": "17950",
+            "name": "newtestintegration8",
+            "integration_type": "oauthandroid"
+          }
+        ],
         "services": []
       }
     }

--- a/test/__fixtures__/config.orgid.no.jwt.aio
+++ b/test/__fixtures__/config.orgid.no.jwt.aio
@@ -20,7 +20,7 @@
         "credentials": [
           {
             "id": "17950",
-            "name": "newtestintegration8",
+            "name": "NewTestIntegration8",
             "integration_type": "oauthandroid"
           }
         ],

--- a/test/__fixtures__/existing.merged.aio
+++ b/test/__fixtures__/existing.merged.aio
@@ -28,17 +28,17 @@
         "credentials": [
           {
             "id": "17561142",
-            "name": "projéct_a",
+            "name": "Projéct_A",
             "integration_type": "oauthweb"
           },
           {
             "id": "17606512",
-            "name": "pröjectb",
+            "name": "PröjectB",
             "integration_type": "service"
           },
           {
             "id": "17950",
-            "name": "new_test_intégration_8",
+            "name": "New_Test_Intégration_8",
             "integration_type": "oauthandroid"
           }
         ],

--- a/test/__fixtures__/existing.merged.aio
+++ b/test/__fixtures__/existing.merged.aio
@@ -25,6 +25,23 @@
       "action_url": "https://ABCD-TestProject-TestWorkspace.adobeioruntime.net",
       "app_url": "https://ABCD-TestProject-TestWorkspace.adobestatic.net",
       "details": {
+        "credentials": [
+          {
+            "id": "17561142",
+            "name": "projéct_a",
+            "integration_type": "oauthweb"
+          },
+          {
+            "id": "17606512",
+            "name": "pröjectb",
+            "integration_type": "service"
+          },
+          {
+            "id": "17950",
+            "name": "new_test_intégration_8",
+            "integration_type": "oauthandroid"
+          }
+        ],
         "services": [
           {
             "code": "AdobeIOManagementAPISDK",

--- a/test/__fixtures__/valid.config.aio
+++ b/test/__fixtures__/valid.config.aio
@@ -17,6 +17,23 @@
       "action_url": "https://ABCD-TestProject-TestWorkspace.adobeioruntime.net",
       "app_url": "https://ABCD-TestProject-TestWorkspace.adobestatic.net",
       "details": {
+        "credentials": [
+          {
+            "id": "17561142",
+            "name": "projéct_a",
+            "integration_type": "oauthweb"
+          },
+          {
+            "id": "17606512",
+            "name": "pröjectb",
+            "integration_type": "service"
+          },
+          {
+            "id": "17950",
+            "name": "new_test_intégration_8",
+            "integration_type": "oauthandroid"
+          }
+        ],
         "services": [
           {
             "code": "AdobeIOManagementAPISDK",

--- a/test/__fixtures__/valid.config.aio
+++ b/test/__fixtures__/valid.config.aio
@@ -20,17 +20,17 @@
         "credentials": [
           {
             "id": "17561142",
-            "name": "projéct_a",
+            "name": "Projéct_A",
             "integration_type": "oauthweb"
           },
           {
             "id": "17606512",
-            "name": "pröjectb",
+            "name": "PröjectB",
             "integration_type": "service"
           },
           {
             "id": "17950",
-            "name": "new_test_intégration_8",
+            "name": "New_Test_Intégration_8",
             "integration_type": "oauthandroid"
           }
         ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently there is no way to know if the credentials belong to the workspace or not and what is the integration id.
This PR adds the credentials reference and id into the workspace config so that the credentials can be retrieved from the .env using that key
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
