### PR TITLE
add: config ui dir

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -59,7 +59,7 @@ class Deploy extends BaseCommand {
           }
         }
         if (!flags['skip-static']) {
-          if (fs.existsSync('web-src/')) {
+          if (fs.existsSync(config.web.src)) {
             if (config.app && config.app.hasBackend) {
               const urls = await rtLib.utils.getActionUrls(config)
               await writeConfig(config.web.injectedConfig, urls)
@@ -104,7 +104,7 @@ class Deploy extends BaseCommand {
           }
         }
         if (!flags['skip-static']) {
-          if (fs.existsSync('web-src/')) {
+          if (fs.existsSync(config.web.src)) {
             spinner.start('Deploying web assets')
             deployedFrontendUrl = await webLib.deployWeb(config, onProgress)
             spinner.succeed(chalk.green('Deploying web assets'))

--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -32,9 +32,9 @@ const CONFIG_KEY = 'aio-dev.dev-keys'
 class Run extends BaseCommand {
   async run (args = []) {
     const { flags } = this.parse(Run)
-
-    const hasFrontend = await fs.exists('web-src/')
-    const hasBackend = await fs.exists('manifest.yml')
+    const devConfig = require('../../lib/config-loader')()
+    const hasFrontend = fs.existsSync(devConfig.web.src)
+    const hasBackend = fs.existsSync('manifest.yml')
 
     if (!hasBackend && !hasFrontend) {
       this.error(wrapError('nothing to run.. there is no web-src/ and no manifest.yml, are you in a valid app?'))
@@ -183,6 +183,9 @@ Run.flags = {
   'skip-actions': flags.boolean({
     description: 'skip actions, only run the ui server',
     exclusive: ['local']
+  }),
+  'skip-build': flags.boolean({
+    description: 'skip frontend build, only run actions'
   }),
   open: flags.boolean({
     description: 'Open the default web browser after a successful run, only valid if your app has a front-end',

--- a/src/commands/app/undeploy.js
+++ b/src/commands/app/undeploy.js
@@ -46,7 +46,7 @@ class Undeploy extends BaseCommand {
         }
       }
       if (!flags['skip-static']) {
-        if (fs.existsSync('web-src/')) {
+        if (fs.existsSync(config.web.src)) {
           await webLib.undeployWeb(config, onProgress)
         } else {
           this.log('no web-src, skipping web-src undeploy')

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -18,6 +18,7 @@ const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-
 const { getToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
 const fetch = require('node-fetch')
+const aioRunDetached = require('@adobe/aio-run-detached')
 
 /** @private */
 function isNpmInstalled () {
@@ -76,6 +77,23 @@ async function runPackageScript (scriptName, dir, cmdArgs = []) {
       }
     })
     return child
+  } else {
+    aioLogger.debug(`${dir} does not contain a package.json or it does not contain a script named ${scriptName}`)
+  }
+}
+
+/** @private */
+async function runPackageScriptDetached (scriptName, dir, cmdArgs = []) {
+  if (!dir) {
+    dir = process.cwd()
+  }
+  aioLogger.debug(`running npm run-script ${scriptName} in dir: ${dir}`)
+  const pkg = await fs.readJSON(path.join(dir, 'package.json'))
+  if (pkg && pkg.scripts && pkg.scripts[scriptName]) {
+    const command = pkg.scripts[scriptName].split(' ')
+
+    const child = aioRunDetached.run(command, dir)
+
   } else {
     aioLogger.debug(`${dir} does not contain a package.json or it does not contain a script named ${scriptName}`)
   }
@@ -352,6 +370,7 @@ module.exports = {
   isGitInstalled,
   installPackage,
   runPackageScript,
+  runPackageScriptDetached,
   wrapError,
   getCliInfo,
   getActionUrls,

--- a/src/lib/config-loader.js
+++ b/src/lib/config-loader.js
@@ -102,6 +102,14 @@ module.exports = () => {
   config.web.distProd = _abs(path.join(dist, `${web}-prod`))
   config.web.injectedConfig = _abs(path.join(web, 'src', 'config.json'))
 
+  // custom UI run and build commands if specified
+  if (userConfig.cna.runScript) {
+    config.web.runScript = userConfig.cna.runScript
+  }
+  if (userConfig.cna.buildScript) {
+    config.web.buildScript = userConfig.cna.buildScript
+  }
+
   config.s3.credsCacheFile = _abs('.aws.tmp.creds.json')
   config.manifest.src = _abs('manifest.yml')
 
@@ -117,7 +125,7 @@ module.exports = () => {
 
   // check if the app has a frontend, for now enforce index.html to be there
   // todo we shouldn't have any config.web config if !hasFrontend
-  config.app.hasFrontend = fs.existsSync(path.join(config.web.src, 'index.html'))
+  config.app.hasFrontend = fs.existsSync(config.web.src)
 
   // check if the app has a backend by checking presence of manifest.yml file
   config.app.hasBackend = fs.existsSync(config.manifest.src)


### PR DESCRIPTION
## Local Development

[Sample FF project with CRA](https://github.com/rajarju/ff-react-app)

### 1. Single terminal window
- Have frontend code in a directory under ff app
- config .aio file to add
  - web - the path to the frontend directory
  - runScript - Package script to run frontend locally
- run `aio app run` to run the ui locally

### Issues with this approach
- The frontend script would use the same stdout as `aio app run`
- In case of `react-script` it would clear the logs before it runs, which would remove all the logs written by `aio app run` from stdout

### 2. Run frontend build as a separate process
- Have frontend code in a directory under ff app
- config .aio file to add
  - web - the path to the frontend directory
- run the custom frontend build/dev in a separate window (npm start)
- run `aio app run --skip-build` to run the ff app locally without frontend (parcel) build
- this would still create the config.json file inside `<cna.web>/src/config.json`

### Issues with this approach
- Devs will have to run frontend and backend (ff app) separately for local development

### 3. Running frontend script using aio-run-detached
- Have frontend code in a directory under ff app
- Install `aio-run-detached` as a dev dependency on frontend project
- add a custom dev script which runs the dev command using `aio-run-detached`
  - `"start:detached": "aio-run-detached react-scripts start"`


## Building and deploying

Ideally, developers should be able to configure their custom frontend src and build script 
and they should be able to run `aio app deploy` which would build and deploy the code with a single command

With the current version of app cli to deploy the frontend, developers have to
- run the build manually
- copy the build to ff build directory
- run `aio app deploy --skip-build`

### Todo
- Try using pre deploy hooks to run build