### PR TITLE
ACNA-942 - Windows: docker not found when running `aio app run --local --verbose` (openwhisk)

### DIFF
--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -20,8 +20,8 @@ class BaseCommand extends Command {
   getAppConfig () {
     if (!this.appConfig) {
       this.appConfig = loadConfig()
-      // add on app.cliConfig
-      this.appConfig.app.cliConfig = this.config
+      // add on appConfig
+      this.appConfig.cli = this.config
     }
     return this.appConfig
   }

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 const { Command, flags } = require('@oclif/command')
-const fs = require('fs-extra')
 const chalk = require('chalk')
 const coreConfig = require('@adobe/aio-lib-core-config')
 const DEFAULT_LAUNCH_PREFIX = 'https://experience.adobe.com/?devMode=true#/custom-apps/?localDevUrl='
@@ -21,6 +20,8 @@ class BaseCommand extends Command {
   getAppConfig () {
     if (!this.appConfig) {
       this.appConfig = loadConfig()
+      // add on app.cliConfig
+      this.appConfig.app.cliConfig = this.config
     }
     return this.appConfig
   }
@@ -44,10 +45,7 @@ class BaseCommand extends Command {
   }
 
   get pjson () {
-    if (!this._pjson) {
-      this._pjson = fs.readJSONSync('package.json')
-    }
-    return this._pjson
+    return this.config.pjson
   }
 
   get appName () {

--- a/src/lib/owlocal.js
+++ b/src/lib/owlocal.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const path = require('path')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:owlocal', { provider: 'debug' })
 const execa = require('execa')
+const url = require('url')
 
 const OW_LOCAL_DOCKER_PORT = 3233
 
@@ -22,6 +23,26 @@ function isWindowsOrMac () {
     process.platform === 'win32' ||
     process.platform === 'darwin'
   )
+}
+
+/** @private */
+function owJarPath (owJarUrl) {
+  const { pathname } = new url.URL(owJarUrl)
+  const idx = pathname.indexOf('/openwhisk/')
+  let jarPath
+
+  if (idx === -1) {
+    jarPath = path.join('openwhisk', 'openwhisk-standalone.jar') // default path
+    aioLogger.warn(`Could not parse openwhisk jar path from ${owJarUrl}, using default ${jarPath}`)
+  } else {
+    jarPath = pathname
+      .substring(idx + 1) // skip initial forward slash
+      .split(path.posix.sep) // split on forward slashes
+      .join(path.sep) // join on os path separator (for Windows)
+    aioLogger.debug(`Parsed openwhisk jar path from ${owJarUrl}, using ${jarPath}`)
+  }
+
+  return jarPath
 }
 
 /** @private */
@@ -55,6 +76,7 @@ module.exports = {
   getDockerNetworkAddress,
   OW_LOCAL_DOCKER_PORT,
   OW_JAR_URL,
+  OW_JAR_PATH: owJarPath(OW_JAR_URL),
   OW_CONFIG_RUNTIMES_FILE,
   OW_LOCAL_APIHOST,
   OW_LOCAL_NAMESPACE,

--- a/src/lib/owlocal.js
+++ b/src/lib/owlocal.js
@@ -44,9 +44,7 @@ function getDockerNetworkAddress () {
 
 // gets these values if the keys are set in the environment, if not it will use the defaults set
 const {
-  OW_JAR_URL = 'https://dl.bintray.com/adobeio-firefly/aio/openwhisk-standalone.jar',
-  // This path will be relative to this module, and not the cwd, so multiple projects can use it.
-  OW_JAR_FILE = path.resolve(__dirname, '../../bin/openwhisk-standalone.jar'),
+  OW_JAR_URL = 'https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar',
   OW_CONFIG_RUNTIMES_FILE = path.resolve(__dirname, '../../bin/openwhisk-standalone-config/runtimes.json'),
   OW_LOCAL_APIHOST = getDockerNetworkAddress(),
   OW_LOCAL_NAMESPACE = 'guest',
@@ -57,7 +55,6 @@ module.exports = {
   getDockerNetworkAddress,
   OW_LOCAL_DOCKER_PORT,
   OW_JAR_URL,
-  OW_JAR_FILE,
   OW_CONFIG_RUNTIMES_FILE,
   OW_LOCAL_APIHOST,
   OW_LOCAL_NAMESPACE,

--- a/src/lib/runDev.js
+++ b/src/lib/runDev.js
@@ -26,7 +26,7 @@ const DeployActions = require('@adobe/aio-lib-runtime').deployActions
 // const ActionLogs = require('../commands/app/logs')
 const utils = require('./app-helper')
 const EventPoller = require('../lib/poller')
-const { OW_CONFIG_RUNTIMES_FILE, OW_JAR_URL, OW_LOCAL_APIHOST, OW_LOCAL_NAMESPACE, OW_LOCAL_AUTH } = require('../lib/owlocal')
+const { OW_CONFIG_RUNTIMES_FILE, OW_JAR_URL, OW_JAR_PATH, OW_LOCAL_APIHOST, OW_LOCAL_NAMESPACE, OW_LOCAL_AUTH } = require('../lib/owlocal')
 const execa = require('execa')
 const Bundler = require('parcel-bundler')
 const chokidar = require('chokidar')
@@ -44,7 +44,7 @@ const eventPoller = new EventPoller(fetchLogInterval)
 async function runDevLocal (config, cleanup, log) {
   const devConfig = cloneDeep(config)
   devConfig.envFile = path.join(config.app.dist, '.env.local')
-  const owJarFile = path.join(config.app.cliConfig.dataDir, 'openwhisk', 'openwhisk-standalone.jar')
+  const owJarFile = path.join(config.cli.dataDir, OW_JAR_PATH)
 
   // take following steps only when we have a backend
   log('checking if java is installed...')

--- a/test/commands/lib/ow-local.test.js
+++ b/test/commands/lib/ow-local.test.js
@@ -23,7 +23,6 @@ beforeEach(() => {
   delete process.env.OW_CONFIG_RUNTIMES_FILE
   delete process.env.OW_LOCAL_AUTH
   delete process.env.OW_JAR_URL
-  delete process.env.OW_JAR_FILE
   delete process.env.OW_LOCAL_APIHOST
   aioLogger.debug.mockReset()
 })
@@ -36,7 +35,6 @@ describe('owlocal', () => {
     })
     expect(typeof owLocal.getDockerNetworkAddress).toEqual('function')
     expect(owLocal.OW_CONFIG_RUNTIMES_FILE).toEqual(expect.stringContaining(path.normalize('/bin/openwhisk-standalone-config/runtimes.json')))
-    expect(owLocal.OW_JAR_FILE).toEqual(expect.stringContaining(path.normalize('/bin/openwhisk-standalone.jar')))
     expect(owLocal.OW_JAR_URL).toMatch('https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar')
     expect(owLocal.OW_LOCAL_NAMESPACE).toMatch('guest')
     expect(owLocal.OW_LOCAL_AUTH).toMatch('23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP')
@@ -46,14 +44,12 @@ describe('owlocal', () => {
     process.env.OW_CONFIG_RUNTIMES_FILE = 'file'
     process.env.OW_LOCAL_AUTH = '123'
     process.env.OW_JAR_URL = 'example.com'
-    process.env.OW_JAR_FILE = 'hey.jar'
     process.env.OW_LOCAL_APIHOST = 'fake.com'
     let owLocal
     jest.isolateModules(() => {
       owLocal = require('../../../src/lib/owlocal')
     })
     expect(owLocal.OW_CONFIG_RUNTIMES_FILE).toEqual('file')
-    expect(owLocal.OW_JAR_FILE).toMatch('hey.jar')
     expect(owLocal.OW_JAR_URL).toMatch('example.com')
     expect(owLocal.OW_LOCAL_NAMESPACE).toMatch('dude')
     expect(owLocal.OW_LOCAL_AUTH).toMatch('123')

--- a/test/commands/lib/ow-local.test.js
+++ b/test/commands/lib/ow-local.test.js
@@ -37,7 +37,7 @@ describe('owlocal', () => {
     expect(typeof owLocal.getDockerNetworkAddress).toEqual('function')
     expect(owLocal.OW_CONFIG_RUNTIMES_FILE).toEqual(expect.stringContaining(path.normalize('/bin/openwhisk-standalone-config/runtimes.json')))
     expect(owLocal.OW_JAR_FILE).toEqual(expect.stringContaining(path.normalize('/bin/openwhisk-standalone.jar')))
-    expect(owLocal.OW_JAR_URL).toMatch('https://dl.bintray.com/adobeio-firefly/aio/openwhisk-standalone.jar')
+    expect(owLocal.OW_JAR_URL).toMatch('https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar')
     expect(owLocal.OW_LOCAL_NAMESPACE).toMatch('guest')
     expect(owLocal.OW_LOCAL_AUTH).toMatch('23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP')
   })

--- a/test/commands/lib/ow-local.test.js
+++ b/test/commands/lib/ow-local.test.js
@@ -53,7 +53,7 @@ describe('owlocal', () => {
     })
     expect(owLocal.OW_CONFIG_RUNTIMES_FILE).toEqual('file')
     expect(owLocal.OW_JAR_URL).toMatch('https://example.com/openwhisk/foo/bar.jar')
-    expect(owLocal.OW_JAR_PATH).toMatch('openwhisk/foo/bar.jar')
+    expect(owLocal.OW_JAR_PATH).toMatch(path.join('openwhisk', 'foo', 'bar.jar'))
     expect(owLocal.OW_LOCAL_NAMESPACE).toMatch('dude')
     expect(owLocal.OW_LOCAL_AUTH).toMatch('123')
     expect(owLocal.OW_LOCAL_APIHOST).toMatch('fake.com')
@@ -66,7 +66,7 @@ describe('owlocal', () => {
       owLocal = require('../../../src/lib/owlocal')
     })
     expect(owLocal.OW_JAR_URL).toMatch('https://example.com/some/path')
-    expect(owLocal.OW_JAR_PATH).toMatch('openwhisk/openwhisk-standalone.jar')
+    expect(owLocal.OW_JAR_PATH).toMatch(path.join('openwhisk', 'openwhisk-standalone.jar'))
   })
 
   describe('getDockerNetworkAddress', () => {

--- a/test/commands/lib/ow-local.test.js
+++ b/test/commands/lib/ow-local.test.js
@@ -36,25 +36,39 @@ describe('owlocal', () => {
     expect(typeof owLocal.getDockerNetworkAddress).toEqual('function')
     expect(owLocal.OW_CONFIG_RUNTIMES_FILE).toEqual(expect.stringContaining(path.normalize('/bin/openwhisk-standalone-config/runtimes.json')))
     expect(owLocal.OW_JAR_URL).toMatch('https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar')
+    expect(owLocal.OW_JAR_PATH).toMatch(path.join('openwhisk', 'standalone-v1', 'openwhisk-standalone.jar'))
     expect(owLocal.OW_LOCAL_NAMESPACE).toMatch('guest')
     expect(owLocal.OW_LOCAL_AUTH).toMatch('23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP')
   })
+
   test('exports can be overwritten by process env', () => {
     process.env.OW_LOCAL_NAMESPACE = 'dude'
     process.env.OW_CONFIG_RUNTIMES_FILE = 'file'
     process.env.OW_LOCAL_AUTH = '123'
-    process.env.OW_JAR_URL = 'example.com'
+    process.env.OW_JAR_URL = 'https://example.com/openwhisk/foo/bar.jar'
     process.env.OW_LOCAL_APIHOST = 'fake.com'
     let owLocal
     jest.isolateModules(() => {
       owLocal = require('../../../src/lib/owlocal')
     })
     expect(owLocal.OW_CONFIG_RUNTIMES_FILE).toEqual('file')
-    expect(owLocal.OW_JAR_URL).toMatch('example.com')
+    expect(owLocal.OW_JAR_URL).toMatch('https://example.com/openwhisk/foo/bar.jar')
+    expect(owLocal.OW_JAR_PATH).toMatch('openwhisk/foo/bar.jar')
     expect(owLocal.OW_LOCAL_NAMESPACE).toMatch('dude')
     expect(owLocal.OW_LOCAL_AUTH).toMatch('123')
     expect(owLocal.OW_LOCAL_APIHOST).toMatch('fake.com')
   })
+
+  test('use defaults for OW_JAR_PATH if path not found in OW_JAR_URL', () => {
+    process.env.OW_JAR_URL = 'https://example.com/some/path'
+    let owLocal
+    jest.isolateModules(() => {
+      owLocal = require('../../../src/lib/owlocal')
+    })
+    expect(owLocal.OW_JAR_URL).toMatch('https://example.com/some/path')
+    expect(owLocal.OW_JAR_PATH).toMatch('openwhisk/openwhisk-standalone.jar')
+  })
+
   describe('getDockerNetworkAddress', () => {
     test('is not windows or mac', () => {
       Object.defineProperty(process, 'platform', {
@@ -85,6 +99,7 @@ describe('owlocal', () => {
       expect(execa.sync).not.toHaveBeenCalled()
       expect(owLocal.OW_LOCAL_APIHOST).toEqual('http://localhost:3233')
     })
+
     test('is mac', () => {
       Object.defineProperty(process, 'platform', {
         value: 'darwin'
@@ -97,6 +112,7 @@ describe('owlocal', () => {
       expect(execa.sync).not.toHaveBeenCalled()
       expect(owLocal.OW_LOCAL_APIHOST).toEqual('http://localhost:3233')
     })
+
     test('if execa fails', () => {
       Object.defineProperty(process, 'platform', {
         value: 'abc'

--- a/test/commands/lib/runDev.test.js
+++ b/test/commands/lib/runDev.test.js
@@ -144,10 +144,9 @@ const CLI_CONFIG = {
 }
 
 // those must match the ones defined in dev.js
-const OW_JAR_FILE = path.join('openwhisk', 'openwhisk-standalone.jar')
-const OW_JAR_PATH = path.join(CLI_CONFIG.dataDir, OW_JAR_FILE)
 const OW_RUNTIMES_CONFIG = path.resolve(__dirname, '../../../bin/openwhisk-standalone-config/runtimes.json')
 const OW_JAR_URL = 'https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar'
+const OW_JAR_PATH = path.join(CLI_CONFIG.dataDir, 'openwhisk', 'standalone-v1', 'openwhisk-standalone.jar')
 const WAIT_INIT_TIME = 2000
 const WAIT_PERIOD_TIME = 500
 
@@ -164,7 +163,7 @@ async function loadEnvScripts (project, config, excludeFiles = []) {
   process.chdir('/')
 
   const appConfig = loadConfig()
-  appConfig.app.cliConfig = CLI_CONFIG
+  appConfig.cli = CLI_CONFIG
   return appConfig
 }
 

--- a/test/commands/lib/runDev.test.js
+++ b/test/commands/lib/runDev.test.js
@@ -148,7 +148,7 @@ const expectedRemoteOWConfig = expect.objectContaining({
 const owJarFile = 'openwhisk-standalone.jar'
 const owJarPath = path.resolve(__dirname, '../../../bin/' + owJarFile)
 const owRuntimesConfig = path.resolve(__dirname, '../../../bin/openwhisk-standalone-config/runtimes.json')
-const owJarUrl = 'https://dl.bintray.com/adobeio-firefly/aio/openwhisk-standalone.jar'
+const owJarUrl = 'https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar'
 const waitInitTime = 2000
 const waitPeriodTime = 500
 

--- a/test/commands/lib/runDev.test.js
+++ b/test/commands/lib/runDev.test.js
@@ -169,15 +169,22 @@ async function loadEnvScripts (project, config, excludeFiles = []) {
 }
 
 /** @private */
+function posixPath (pathString) {
+  return pathString
+    .split(path.sep)
+    .join(path.posix.sep)
+}
+
+/** @private */
 function writeFakeOwJar () {
   global.fakeFileSystem.addJson({
-    [OW_JAR_PATH]: 'fakecontent'
+    [posixPath(OW_JAR_PATH)]: 'fakecontent'
   })
 }
 
 /** @private */
 function deleteFakeOwJar () {
-  global.fakeFileSystem.removeKeys(OW_JAR_PATH)
+  global.fakeFileSystem.removeKeys(posixPath(OW_JAR_PATH))
 }
 
 // helpers for checking good path
@@ -203,7 +210,7 @@ function expectUIServer (fakeMiddleware, port) {
 /** @private */
 function expectAppFiles (expectedFiles) {
   const expectedFileSet = new Set(expectedFiles)
-  const files = new Set(Object.keys(global.fakeFileSystem.files()).filter(filePath => !filePath.includes(OW_JAR_FILE)))
+  const files = new Set(Object.keys(global.fakeFileSystem.files()).filter(filePath => !filePath.includes(posixPath(OW_JAR_PATH))))
   // in run local, the openwhisk standalone jar is created at __dirname,
   // but as we store the app in the root of the memfs, we need to ignore the extra created folder
   expect(files).toEqual(expectedFileSet)
@@ -676,8 +683,8 @@ function runCommonLocalTests (ref) {
     await runDev([], ref.config)
 
     expect(fetch).toHaveBeenCalledWith(OW_JAR_URL)
-    expect(OW_JAR_PATH in global.fakeFileSystem.files()).toEqual(true)
-    expect(global.fakeFileSystem.files()[OW_JAR_PATH].toString()).toEqual('fakeowjar')
+    expect(posixPath(OW_JAR_PATH) in global.fakeFileSystem.files()).toEqual(true)
+    expect(global.fakeFileSystem.files()[posixPath(OW_JAR_PATH)].toString()).toEqual('fakeowjar')
   })
 
   test('should fail if downloading openwhisk-standalone.jar creates a stream error', async () => {

--- a/test/commands/lib/runDev.test.js
+++ b/test/commands/lib/runDev.test.js
@@ -78,7 +78,6 @@ const now = Date.now
 let time
 
 beforeEach(() => {
-  // global.cleanFs(vol)
   global.fakeFileSystem.reset()
   delete process.env.REMOTE_ACTIONS
 
@@ -117,10 +116,6 @@ beforeEach(() => {
   deployActionsSpy.mockResolvedValue({})
 })
 
-afterAll(() => {
-  // deployActionsSpy.mockRestore()
-})
-
 /* ****************** Consts ******************* */
 
 const localOWCredentials = {
@@ -144,15 +139,19 @@ const expectedRemoteOWConfig = expect.objectContaining({
   })
 })
 
-// those must match the ones defined in dev.js
-const owJarFile = 'openwhisk-standalone.jar'
-const owJarPath = path.resolve(__dirname, '../../../bin/' + owJarFile)
-const owRuntimesConfig = path.resolve(__dirname, '../../../bin/openwhisk-standalone-config/runtimes.json')
-const owJarUrl = 'https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar'
-const waitInitTime = 2000
-const waitPeriodTime = 500
+const CLI_CONFIG = {
+  dataDir: path.join('/', 'dataDir')
+}
 
-const execaLocalOWArgs = ['java', expect.arrayContaining(['-jar', path.resolve(owJarPath), '-m', owRuntimesConfig, '--no-ui']), expect.anything()]
+// those must match the ones defined in dev.js
+const OW_JAR_FILE = path.join('openwhisk', 'openwhisk-standalone.jar')
+const OW_JAR_PATH = path.join(CLI_CONFIG.dataDir, OW_JAR_FILE)
+const OW_RUNTIMES_CONFIG = path.resolve(__dirname, '../../../bin/openwhisk-standalone-config/runtimes.json')
+const OW_JAR_URL = 'https://bintray.com/api/ui/download/adobe/generic/openwhisk/standalone-v1/openwhisk-standalone.jar'
+const WAIT_INIT_TIME = 2000
+const WAIT_PERIOD_TIME = 500
+
+const EXECA_LOCAL_OW_ARGS = ['java', expect.arrayContaining(['-jar', OW_JAR_PATH, '-m', OW_RUNTIMES_CONFIG, '--no-ui']), expect.anything()]
 
 /* ****************** Helpers ******************* */
 
@@ -163,31 +162,22 @@ async function loadEnvScripts (project, config, excludeFiles = []) {
   excludeFiles.forEach(f => global.fakeFileSystem.removeKeys([f]))
   mockAIOConfig.get.mockReturnValue(config)
   process.chdir('/')
-  return loadConfig()
+
+  const appConfig = loadConfig()
+  appConfig.app.cliConfig = CLI_CONFIG
+  return appConfig
 }
 
 /** @private */
 function writeFakeOwJar () {
-  // global.addFakeFiles(vol, path.dirname(owJarPath), path.basename(owJarPath))
-  const fakeFsJson = {}
-  fakeFsJson[path.dirname(owJarPath) + '/' + path.basename(owJarPath)] = 'fake-content'
-  global.fakeFileSystem.addJson(fakeFsJson)
+  global.fakeFileSystem.addJson({
+    [OW_JAR_PATH]: 'fakecontent'
+  })
 }
 
 /** @private */
 function deleteFakeOwJar () {
-  global.fakeFileSystem.removeKeys([deriveOwJarFilePath()])
-}
-
-/** @private */
-function deriveOwJarFilePath () {
-  let owJarFilePath
-  Object.keys(global.fakeFileSystem.files()).forEach(filePath => {
-    if (filePath.includes(owJarFile)) {
-      owJarFilePath = filePath
-    }
-  })
-  return owJarFilePath
+  global.fakeFileSystem.removeKeys(OW_JAR_PATH)
 }
 
 // helpers for checking good path
@@ -196,10 +186,8 @@ function expectDevActionBuildAndDeploy (expectedBuildDeployConfig) {
   // build & deploy
   expect(BuildActions).toHaveBeenCalledTimes(1)
   expect(BuildActions.mock.calls[0][0]).toEqual(expectedBuildDeployConfig)
-  // expect(BuildActions.mock.instances[1].run).toHaveBeenCalledTimes(1)
   expect(DeployActions).toHaveBeenCalledTimes(1)
   expect(DeployActions.mock.calls[0][0]).toEqual(expectedBuildDeployConfig)
-  // expect(DeployActions.mock.instances[1].run).toHaveBeenCalledTimes(1)
 }
 
 /** @private */
@@ -215,7 +203,7 @@ function expectUIServer (fakeMiddleware, port) {
 /** @private */
 function expectAppFiles (expectedFiles) {
   const expectedFileSet = new Set(expectedFiles)
-  const files = new Set(Object.keys(global.fakeFileSystem.files()).filter(filePath => !filePath.includes(owJarFile)))
+  const files = new Set(Object.keys(global.fakeFileSystem.files()).filter(filePath => !filePath.includes(OW_JAR_FILE)))
   // in run local, the openwhisk standalone jar is created at __dirname,
   // but as we store the app in the root of the memfs, we need to ignore the extra created folder
   expect(files).toEqual(expectedFileSet)
@@ -516,14 +504,12 @@ function runCommonRemoteTests (ref) {
     // The second call to DeployActions will result in an error because of the second mock above
     expect(log).toHaveBeenLastCalledWith(expect.stringContaining('Stopping'))
     expect(BuildActions).toHaveBeenCalledTimes(2)
-    // expect(BuildActions.mock.instances[0].run).toHaveBeenCalledTimes(1)
     expect(DeployActions).toHaveBeenCalledTimes(2)
-    // expect(DeployActions.mock.instances[0].run).toHaveBeenCalledTimes(1)
   })
 
   test('should not start the local openwhisk stack', async () => {
     await runDev([], ref.config)
-    expect(execa).not.toHaveBeenCalledWith(...execaLocalOWArgs)
+    expect(execa).not.toHaveBeenCalledWith(...EXECA_LOCAL_OW_ARGS)
   })
 
   test('should not generate a /dist/.env.local file with the remote credentials', async () => {
@@ -689,9 +675,9 @@ function runCommonLocalTests (ref) {
 
     await runDev([], ref.config)
 
-    expect(fetch).toHaveBeenCalledWith(owJarUrl)
-    expect(deriveOwJarFilePath() in global.fakeFileSystem.files()).toEqual(true)
-    expect(global.fakeFileSystem.files()[deriveOwJarFilePath()].toString()).toEqual('fakeowjar')
+    expect(fetch).toHaveBeenCalledWith(OW_JAR_URL)
+    expect(OW_JAR_PATH in global.fakeFileSystem.files()).toEqual(true)
+    expect(global.fakeFileSystem.files()[OW_JAR_PATH].toString()).toEqual('fakeowjar')
   })
 
   test('should fail if downloading openwhisk-standalone.jar creates a stream error', async () => {
@@ -717,7 +703,7 @@ function runCommonLocalTests (ref) {
   test('should fail when there is a connection error while downloading openwhisk-standalone.jar on first usage', async () => {
     deleteFakeOwJar()
     fetch.mockRejectedValue(new Error('fake connection error'))
-    await expect(runDev([], ref.config)).rejects.toEqual(expect.objectContaining({ message: `connection error while downloading '${owJarUrl}', are you online?` }))
+    await expect(runDev([], ref.config)).rejects.toEqual(expect.objectContaining({ message: `connection error while downloading '${OW_JAR_URL}', are you online?` }))
   })
 
   test('should fail if fetch fails to download openwhisk-standalone.jar on first usage because of status error', async () => {
@@ -726,7 +712,7 @@ function runCommonLocalTests (ref) {
       ok: false,
       statusText: 404
     })
-    await expect(runDev([], ref.config)).rejects.toEqual(expect.objectContaining({ message: `unexpected response while downloading '${owJarUrl}': 404` }))
+    await expect(runDev([], ref.config)).rejects.toEqual(expect.objectContaining({ message: `unexpected response while downloading '${OW_JAR_URL}': 404` }))
   })
 
   test('should build and deploy actions to local ow', async () => {
@@ -772,7 +758,7 @@ function runCommonLocalTests (ref) {
   test('should kill openwhisk-standalone subprocess on error', async () => {
     const owProcessMockKill = jest.fn()
     execa.mockImplementation((cmd, args) => {
-      if (cmd === 'java' && args.includes('-jar') && args.includes(owJarPath)) {
+      if (cmd === 'java' && args.includes('-jar') && args.includes(OW_JAR_PATH)) {
         return {
           stdout: jest.fn(),
           kill: owProcessMockKill
@@ -784,7 +770,7 @@ function runCommonLocalTests (ref) {
       }
     })
     await testCleanupOnError(ref.config, () => {
-      expect(execa).toHaveBeenCalledWith(...execaLocalOWArgs)
+      expect(execa).toHaveBeenCalledWith(...EXECA_LOCAL_OW_ARGS)
       expect(owProcessMockKill).toHaveBeenCalledTimes(1)
     })
   })
@@ -808,11 +794,11 @@ function runCommonLocalTests (ref) {
     })
 
     await runDev([], ref.config)
-    expect(execa).toHaveBeenCalledWith(...execaLocalOWArgs)
+    expect(execa).toHaveBeenCalledWith(...EXECA_LOCAL_OW_ARGS)
     expect(fetch).toHaveBeenCalledWith('http://localhost:3233/api/v1')
     expect(fetch).toHaveBeenCalledTimes(5)
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), waitInitTime) // initial wait
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), waitPeriodTime) // period wait
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), WAIT_INIT_TIME) // initial wait
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), WAIT_PERIOD_TIME) // period wait
     expect(setTimeout).toHaveBeenCalledTimes(5)
   })
 
@@ -825,10 +811,10 @@ function runCommonLocalTests (ref) {
       return { ok: true }
     })
     await expect(runDev([], ref.config)).rejects.toEqual(expect.objectContaining({ message: 'local openwhisk stack startup timed out: 60000ms' }))
-    expect(execa).toHaveBeenCalledWith(...execaLocalOWArgs)
+    expect(execa).toHaveBeenCalledWith(...EXECA_LOCAL_OW_ARGS)
     expect(fetch).toHaveBeenCalledWith('http://localhost:3233/api/v1')
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), waitInitTime) // initial wait
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), waitPeriodTime) // period wait
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), WAIT_INIT_TIME) // initial wait
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), WAIT_PERIOD_TIME) // period wait
   })
 
   test('should run if local openwhisk-standalone jar startup takes 59seconds', async () => {
@@ -840,10 +826,10 @@ function runCommonLocalTests (ref) {
       return { ok: true }
     })
     await runDev([], ref.config)
-    expect(execa).toHaveBeenCalledWith(...execaLocalOWArgs)
+    expect(execa).toHaveBeenCalledWith(...EXECA_LOCAL_OW_ARGS)
     expect(fetch).toHaveBeenCalledWith('http://localhost:3233/api/v1')
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), waitInitTime) // initial wait
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), waitPeriodTime) // period wait
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), WAIT_INIT_TIME) // initial wait
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), WAIT_PERIOD_TIME) // period wait
   })
 }
 
@@ -940,7 +926,6 @@ describe('with remote actions and frontend', () => {
     mockRuntimeLib.utils.getActionUrls.mockReturnValueOnce(retVal)
     await runDev([], ref.config, { skipActions: true })
     expect('/web-src/src/config.json' in global.fakeFileSystem.files()).toEqual(true)
-    console.log(global.fakeFileSystem.files())
     expect(JSON.parse(global.fakeFileSystem.files()['/web-src/src/config.json'].toString())).toEqual(retVal)
   })
 })

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -29,7 +29,6 @@ global.mockFs = () => {
     addJson: (json) => {
       // add to existing
       fileSystem.mock(json)
-      // console.log(json)
     },
     removeKeys: (arr) => {
       // remove from existing


### PR DESCRIPTION
Two changes:
1. The OpenWhisk jar URL has been updated to include the [Windows Docker fix](https://github.com/apache/openwhisk/pull/5021): https://github.com/adobe/openwhisk/releases/tag/standalone-v1
2. The OpenWhisk jar is not downloaded into the aio-cli-plugin-app's `bin` folder anymore, but in the cli's `dataDir` folder as specified in the [oclif config](https://oclif.io/docs/config). On macOS, this location for `@adobe/aio-cli` is ` ~/.local/share/@adobe/aio-cli/openwhisk/openwhisk-standalone.jar`. This is so the .jar is not deleted on every app plugin update.

## How Has This Been Tested?

npm test
aio app run --local --verbose

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
