### PR TITLE
fix: ACNA-949 - command chaining, and separators broken

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -52,9 +52,13 @@ async function runPackageScript (scriptName, dir, cmdArgs = []) {
   aioLogger.debug(`running npm run-script ${scriptName} in dir: ${dir}`)
   const pkg = await fs.readJSON(path.join(dir, 'package.json'))
   if (pkg && pkg.scripts && pkg.scripts[scriptName]) {
-    const command = pkg.scripts[scriptName].split(' ')
-    const child = execa(command[0], command.slice(1).concat(cmdArgs), {
+    let command = pkg.scripts[scriptName]
+    if (cmdArgs.length) {
+      command = `${command} ${cmdArgs.join(' ')}`
+    }
+    const child = execa.command(command, {
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+      shell: true,
       cwd: dir,
       preferLocal: true
     })


### PR DESCRIPTION
Closes #315 

## How Has This Been Tested?

npm test

app hooks:
1. echo foo && echo bar
2. [[ "a" = "a" ]] && echo ok
3. echo it was okay > someFile.txt
4. cat package.json | jq .name


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
