### PR TITLE
fix: https://localhost:9080 404 Not Found in `aio app run`

### DIFF
--- a/src/lib/runDev.js
+++ b/src/lib/runDev.js
@@ -185,7 +185,7 @@ async function runDev (args = [], config, options = {}, log = () => {}) {
 
       if (!options.skipServe) {
         log('starting local frontend server ..')
-        const entryFile = path.join(devConfig.web.src, '*.html')
+        const entryFile = path.join(devConfig.web.src, 'index.html')
 
         // our defaults here can be overridden by the bundleOptions passed in
         // bundleOptions.https are also passed to bundler.serve

--- a/test/commands/lib/runDev.test.js
+++ b/test/commands/lib/runDev.test.js
@@ -199,7 +199,7 @@ function expectDevActionBuildAndDeploy (expectedBuildDeployConfig) {
 /** @private */
 function expectUIServer (fakeMiddleware, port) {
   expect(Bundler.mockConstructor).toHaveBeenCalledTimes(1)
-  expect(Bundler.mockConstructor).toHaveBeenCalledWith(path.resolve('/web-src/*.html'),
+  expect(Bundler.mockConstructor).toHaveBeenCalledWith(path.resolve('/web-src/index.html'),
     expect.objectContaining({
       watch: true,
       outDir: path.resolve('/dist/web-src-dev')


### PR DESCRIPTION
This was broken from PR https://github.com/adobe/aio-cli-plugin-app/pull/320
Reverting this specific parcel-bunder entryPoint change.

Accessing https://localhost:9080/index.html works, but this is a break in the existing workflow.

This is a parcel-bundler issue: https://github.com/parcel-bundler/parcel/issues/1315 that has been fixed in parcel-bundler@2: https://github.com/parcel-bundler/parcel/pull/3996
We are using parcel-bundler@1.


## How Has This Been Tested?

npm test
aio app run

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
