### PR TITLE
fix: add logging to file for openwhisk-standalone.jar

### DIFF
--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -50,7 +50,8 @@ class Run extends BaseCommand {
       parcel: {
         logLevel: flags.verbose ? 4 : 2
       },
-      fetchLogs: true
+      fetchLogs: true,
+      verbose: flags.verbose
     }
 
     try {

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -268,7 +268,7 @@ async function downloadOWJar (url, outFile) {
 /** @private */
 async function runOpenWhiskJar (jarFile, runtimeConfigFile, apihost, waitInitTime, waitPeriodTime, timeout, /* istanbul ignore next */ execaOptions = {}) {
   aioLogger.debug(`runOpenWhiskJar - jarFile: ${jarFile} runtimeConfigFile ${runtimeConfigFile} apihost: ${apihost} waitInitTime: ${waitInitTime} waitPeriodTime: ${waitPeriodTime} timeout: ${timeout}`)
-  const proc = execa('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', jarFile, '-m', runtimeConfigFile, '--no-ui'], execaOptions)
+  const proc = execa('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', jarFile, '-m', runtimeConfigFile, '--no-ui', '--disable-color-logging'], execaOptions)
   await waitForOpenWhiskReadiness(apihost, waitInitTime, waitPeriodTime, timeout)
   // must wrap in an object as execa return value is awaitable
   return { proc }

--- a/src/lib/owlocal.js
+++ b/src/lib/owlocal.js
@@ -69,7 +69,8 @@ const {
   OW_CONFIG_RUNTIMES_FILE = path.resolve(__dirname, '../../bin/openwhisk-standalone-config/runtimes.json'),
   OW_LOCAL_APIHOST = getDockerNetworkAddress(),
   OW_LOCAL_NAMESPACE = 'guest',
-  OW_LOCAL_AUTH = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP'
+  OW_LOCAL_AUTH = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP',
+  OW_LOCAL_LOG_FILE
 } = process.env
 
 module.exports = {
@@ -80,5 +81,6 @@ module.exports = {
   OW_CONFIG_RUNTIMES_FILE,
   OW_LOCAL_APIHOST,
   OW_LOCAL_NAMESPACE,
-  OW_LOCAL_AUTH
+  OW_LOCAL_AUTH,
+  OW_LOCAL_LOG_FILE
 }

--- a/test/commands/lib/runDev.test.js
+++ b/test/commands/lib/runDev.test.js
@@ -799,7 +799,11 @@ function runCommonLocalTests (ref) {
       return { ok: true }
     })
 
-    await runDev([], ref.config)
+    global.fakeFileSystem.addJson({
+      'dist/somefile.txt': 'some content' // create dist folder
+    })
+
+    await runDev([], ref.config, { verbose: true })
     expect(execa).toHaveBeenCalledWith(...EXECA_LOCAL_OW_ARGS)
     expect(fetch).toHaveBeenCalledWith('http://localhost:3233/api/v1')
     expect(fetch).toHaveBeenCalledTimes(5)


### PR DESCRIPTION
Openwhisk standalone logging to file can be set when `--verbose` is set for `aio app run`.
The log file will be truncated and written to in `dist/openwhisk-local.log.txt`. This log file location can be overridden via the `OW_LOCAL_LOG_FILE` environment variable as well.

This feature is to help with debugging.

## Related Issue

#287 

## How Has This Been Tested?

npm test
aio app run --local --verbose
OW_LOCAL_LOG_FILE=mylog.txt aio app run --local --verbose


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
