### PR TITLE
fix: revert `aio app deploy` flag `--force-build` to default to `true` (backwards compatibility)

### DIFF
--- a/src/commands/app/build.js
+++ b/src/commands/app/build.js
@@ -109,6 +109,8 @@ class Build extends BaseCommand {
 }
 
 Build.description = `Build an Adobe I/O App
+
+This will always force a rebuild unless --no-force-build is set. 
 `
 
 Build.flags = {
@@ -120,7 +122,7 @@ Build.flags = {
     description: 'Skip build of actions'
   }),
   'force-build': flags.boolean({
-    description: 'Forces a build even if one already exists',
+    description: 'Forces a build even if one already exists (default: true)',
     default: true,
     allowNo: true
   }),

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -143,8 +143,7 @@ class Deploy extends BuildCommand {
 
 Deploy.description = `Build and deploy an Adobe I/O App
 
-If a build already exists, it will not build again. 
-Use --force-build to rebuild.
+This will always force a rebuild unless --no-force-build is set. 
 `
 
 Deploy.flags = {
@@ -164,9 +163,10 @@ Deploy.flags = {
     description: 'Skip action build & deploy'
   }),
   'force-build': flags.boolean({
-    description: 'Forces a build even if one already exists (default: false)',
+    description: 'Forces a build even if one already exists (default: true)',
     exclusive: ['skip-build'],
-    default: false
+    default: true,
+    allowNo: true
   }),
   action: flags.string({
     description: 'Deploy only a specific action, the flags can be specified multiple times',

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -142,6 +142,9 @@ class Deploy extends BuildCommand {
 }
 
 Deploy.description = `Build and deploy an Adobe I/O App
+
+If a build already exists, it will not build again. 
+Use --force-build to rebuild.
 `
 
 Deploy.flags = {
@@ -161,7 +164,7 @@ Deploy.flags = {
     description: 'Skip action build & deploy'
   }),
   'force-build': flags.boolean({
-    description: 'Forces a build even if one already exists',
+    description: 'Forces a build even if one already exists (default: false)',
     exclusive: ['skip-build'],
     default: false
   }),

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -118,7 +118,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, verbose: true }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, verbose: true }), expect.anything())
   })
 
   test('build & deploy --skip-static', async () => {
@@ -128,7 +128,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, 'skip-static': true }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, 'skip-static': true }), expect.anything())
   })
 
   test('build & deploy only some actions using --action', async () => {
@@ -139,7 +139,7 @@ describe('run', () => {
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.build).toHaveBeenCalledTimes(1)
 
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, 'skip-static': true, action: ['a', 'b', 'c'] }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, 'skip-static': true, action: ['a', 'b', 'c'] }), expect.anything())
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(mockConfigData, {
       filterEntities: { actions: ['a', 'b', 'c'] }
     },
@@ -154,7 +154,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, 'skip-static': true }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, 'skip-static': true }), expect.anything())
   })
 
   test('build & deploy actions with no actions folder but with a manifest', async () => {
@@ -173,7 +173,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, 'skip-actions': true }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, 'skip-actions': true }), expect.anything())
   })
 
   test('build & deploy with --skip-actions with no static folder', async () => {
@@ -184,7 +184,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, 'skip-actions': true }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, 'skip-actions': true }), expect.anything())
   })
 
   test('build & deploy with no manifest.yml', async () => {
@@ -194,7 +194,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true }), expect.anything())
   })
 
   test('--skip-deploy', async () => {
@@ -203,7 +203,7 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true }), expect.anything())
   })
 
   test('--skip-deploy --verbose', async () => {
@@ -213,7 +213,7 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false, verbose: true }), expect.anything())
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true, verbose: true }), expect.anything())
   })
 
   test('--skip-deploy --skip-static', async () => {
@@ -261,14 +261,14 @@ describe('run', () => {
     expect(command.build).toHaveBeenCalledTimes(0)
   })
 
-  test('--force-build', async () => {
-    command.argv = ['--force-build']
+  test('--no-force-build', async () => {
+    command.argv = ['--no-force-build']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.build).toHaveBeenCalledTimes(1)
-    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': true }), expect.anything()) // force-build is true by default for build cmd
+    expect(command.build).toHaveBeenCalledWith(command.appConfig, expect.objectContaining({ 'force-build': false }), expect.anything()) // force-build is true by default for build cmd
   })
 
   test('deploy should show ui url', async () => {


### PR DESCRIPTION
## How Has This Been Tested?

1. `aio app build --help` (see new Description section of help text)
2. `aio app deploy --help` (see new Description section of help text)
3. `aio app deploy`
4. `aio app deploy --no-force-build`
5. `aio app build`
6. `aio app build --no-force-build`
7. npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
