### PR TITLE
fix: write default app config on app init

### DIFF
--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -15,7 +15,7 @@ const path = require('path')
 const fs = require('fs-extra')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:init', { provider: 'debug' })
 const { flags } = require('@oclif/command')
-const { loadAndValidateConfigFile, importConfigJson } = require('../../lib/import')
+const { loadAndValidateConfigFile, importConfigJson, writeDefaultAppConfig } = require('../../lib/import')
 const { getCliInfo } = require('../../lib/app-helper')
 const chalk = require('chalk')
 const { servicesToGeneratorInput } = require('../../lib/app-helper')
@@ -111,6 +111,9 @@ class InitCommand extends BaseCommand {
         fs.unlinkSync(flags.import)
       }
     }
+
+    //write default app config to .aio file
+    writeDefaultAppConfig(process.cwd(), { interactive, merge })
 
     // finalize configuration data
     this.log('✔ App initialization finished!')

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -112,7 +112,7 @@ class InitCommand extends BaseCommand {
       }
     }
 
-    //write default app config to .aio file
+    // write default app config to .aio file
     writeDefaultAppConfig(process.cwd(), { interactive, merge })
 
     // finalize configuration data

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -447,7 +447,6 @@ async function writeConsoleConfig (json) {
  * @returns {Promise} promise from writeFile call
  */
 async function writeAio (json, parentFolder, flags) {
-  console.log('-----------writting aio-------------------------')
   aioLogger.debug(`writeAio - parentFolder:${parentFolder} flags:${flags}`)
   aioLogger.debug(`writeAio - json: ${prettyPrintJson(json)}`)
 
@@ -455,7 +454,6 @@ async function writeAio (json, parentFolder, flags) {
   aioLogger.debug(`writeAio - destination: ${destination}`)
 
   const data = prettyPrintJson(json)
-  console.log('-----------done-------------------------')
   return writeFile(destination, data, flags)
 }
 

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -106,12 +106,14 @@ function loadAndValidateConfigFile (fileOrBuffer) {
  * @returns {Promise} promise from writeFile call
  */
 function writeDefaultAppConfig (parentDir, flags) {
-  //write app config to .aio file
-  const appConfig = { app : {
-    actions: 'actions',
-    dist: 'dist',
-    web: 'web-src'
-  }}
+  // write app config to .aio file
+  const appConfig = {
+    app: {
+      actions: 'actions',
+      dist: 'dist',
+      web: 'web-src'
+    }
+  }
   return writeAio(appConfig, parentDir, flags)
 }
 

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -96,6 +96,26 @@ function loadAndValidateConfigFile (fileOrBuffer) {
 }
 
 /**
+ * Writes default app config to .aio file
+ *
+ * @param {string} parentDir the parent folder to write the .aio file to
+ * @param {object} [flags] flags for file writing
+ * @param {boolean} [flags.overwrite=false] set to true to overwrite the existing .env file
+ * @param {boolean} [flags.merge=false] set to true to merge in the existing .env file (takes precedence over overwrite)
+ * @param {boolean} [flags.interactive=false] set to true to prompt the user for file overwrite
+ * @returns {Promise} promise from writeFile call
+ */
+function writeDefaultAppConfig (parentDir, flags) {
+  //write app config to .aio file
+  const appConfig = { app : {
+    actions: 'actions',
+    dist: 'dist',
+    web: 'web-src'
+  }}
+  return writeAio(appConfig, parentDir, flags)
+}
+
+/**
  * Pretty prints the json object as a string.
  * Delimited by 2 spaces.
  *
@@ -425,6 +445,7 @@ async function writeConsoleConfig (json) {
  * @returns {Promise} promise from writeFile call
  */
 async function writeAio (json, parentFolder, flags) {
+  console.log('-----------writting aio-------------------------')
   aioLogger.debug(`writeAio - parentFolder:${parentFolder} flags:${flags}`)
   aioLogger.debug(`writeAio - json: ${prettyPrintJson(json)}`)
 
@@ -432,6 +453,7 @@ async function writeAio (json, parentFolder, flags) {
   aioLogger.debug(`writeAio - destination: ${destination}`)
 
   const data = prettyPrintJson(json)
+  console.log('-----------done-------------------------')
   return writeFile(destination, data, flags)
 }
 
@@ -598,6 +620,7 @@ module.exports = {
   loadAndValidateConfigFile,
   writeConsoleConfig,
   writeAio,
+  writeDefaultAppConfig,
   writeEnv,
   flattenObjectWithSeparator,
   importConfigJson,

--- a/test/commands/lib/import.test.js
+++ b/test/commands/lib/import.test.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { importConfigJson, writeAio, writeEnv, mergeEnv, splitEnvLine, flattenObjectWithSeparator, loadConfigFile } = require('../../../src/lib/import')
+const { importConfigJson, writeAio, writeEnv, mergeEnv, splitEnvLine, flattenObjectWithSeparator, loadConfigFile, writeDefaultAppConfig } = require('../../../src/lib/import')
 const fs = require('fs-extra')
 const path = require('path')
 const inquirer = require('inquirer')
@@ -30,6 +30,9 @@ test('exports', () => {
 
   expect(writeEnv).toBeDefined()
   expect(writeEnv).toBeInstanceOf(Function)
+
+  expect(writeDefaultAppConfig).toBeDefined()
+  expect(writeDefaultAppConfig).toBeInstanceOf(Function)
 
   expect(flattenObjectWithSeparator).toBeDefined()
   expect(flattenObjectWithSeparator).toBeInstanceOf(Function)
@@ -75,6 +78,19 @@ test('writeAio', async () => {
   await expect(fs.writeFile.mock.calls[2][1]).toMatchFixture(destination)
 
   return expect(fs.writeFile).toHaveBeenCalledTimes(3)
+})
+
+test('writeDefaultAppConfig', async () => {
+  const parentFolder = 'my-parent-folder'
+  const aioPath = path.join(parentFolder, '.aio')
+
+  writeDefaultAppConfig(parentFolder, { overwrite: true })
+  await expect(fs.writeFile.mock.calls[0][0]).toMatch(aioPath)
+
+  writeDefaultAppConfig(parentFolder, { overwrite: false })
+  await expect(fs.writeFile.mock.calls[1][0]).toMatch(aioPath)
+
+  return expect(fs.writeFile).toHaveBeenCalledTimes(2)
 })
 
 test('splitEnvLine', () => {

--- a/test/commands/lib/import.test.js
+++ b/test/commands/lib/import.test.js
@@ -83,12 +83,21 @@ test('writeAio', async () => {
 test('writeDefaultAppConfig', async () => {
   const parentFolder = 'my-parent-folder'
   const aioPath = path.join(parentFolder, '.aio')
+  const defaultAppConfig = {
+    app: {
+      actions: 'actions',
+      dist: 'dist',
+      web: 'web-src'
+    }
+  }
 
   writeDefaultAppConfig(parentFolder, { overwrite: true })
   await expect(fs.writeFile.mock.calls[0][0]).toMatch(aioPath)
+  await expect(JSON.parse(fs.writeFile.mock.calls[0][1])).toMatchObject(defaultAppConfig)
 
   writeDefaultAppConfig(parentFolder, { overwrite: false })
   await expect(fs.writeFile.mock.calls[1][0]).toMatch(aioPath)
+  await expect(JSON.parse(fs.writeFile.mock.calls[1][1])).toMatchObject(defaultAppConfig)
 
   return expect(fs.writeFile).toHaveBeenCalledTimes(2)
 })


### PR DESCRIPTION
Always create .aio file with default app config for app init command.
Fixes #355 

## Description

When aio app is initialised with -y flag, .aio file was not created. 
Fixed this by writing .aio file with default app config at app init. When import or CLI login is used, .aio file will be merged with project config.
Default app config includes, name of actions, dist and web-src folder. This will help users to customise app if required.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

unit tests, manual app init test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
