### PR TITLE
fix: use of generator-aio-app/add-vscode-config generator

### DIFF
--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -137,7 +137,7 @@ async function runDev (args = [], config, options = {}, log = () => {}) {
 
     log('setting up vscode debug configuration files...')
     const vscodeConfig = vscode(devConfig)
-    await vscodeConfig.update({ hasFrontend, withBackend, frontEndUrl })
+    await vscodeConfig.update({ frontEndUrl })
     cleanup.add(() => vscodeConfig.cleanup(), 'cleaning up vscode debug configuration files...')
 
     // automatically fetch logs if there are actions

--- a/src/lib/vscode.js
+++ b/src/lib/vscode.js
@@ -14,7 +14,7 @@ const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-
 const rtLibUtils = require('@adobe/aio-lib-runtime').utils
 const fs = require('fs-extra')
 const path = require('path')
-const cloneDeep = require('lodash.clonedeep')
+const yeoman = require('yeoman-environment')
 
 const LAUNCH_JSON_FILE = '.vscode/launch.json'
 const LAUNCH_JSON_FILE_BACKUP = '.vscode/launch.json.save'
@@ -38,7 +38,17 @@ function update (config) {
         fs.moveSync(mainFile, backupFile)
       }
     }
-    fs.writeJSONSync(mainFile, await generateConfig(config, props), { spaces: 2 })
+
+    const generator = '@adobe/generator-aio-app/generators/add-vscode-config'
+    const env = yeoman.createEnv()
+    env.register(require.resolve(generator), 'gen')
+
+    await env.run('gen', {
+      'app-config': config,
+      'env-file': config.envFile,
+      'frontend-url': props.frontEndUrl,
+      'skip-prompt': true
+    })
   }
 }
 
@@ -61,118 +71,6 @@ function cleanup (config) {
       fs.moveSync(backupFile, mainFile, { overwrite: true })
     }
   }
-}
-
-/** @private */
-function processPackageActionConfigs (appConfig, packageName, pkg) {
-  const { ow, root, envFile } = appConfig
-
-  const actionConfigNames = []
-  const actionConfigs = Object.keys(pkg.actions).map(an => {
-    const name = `Action:${packageName}/${an}`
-    actionConfigNames.push(name)
-    const action = pkg.actions[an]
-    const actionPath = rtLibUtils._absApp(root, action.function)
-
-    const config = {
-      type: 'pwa-node',
-      request: 'launch',
-      name: name,
-      runtimeExecutable: rtLibUtils._absApp(root, './node_modules/.bin/wskdebug'),
-      envFile: path.join('${workspaceFolder}', envFile), // eslint-disable-line no-template-curly-in-string
-      timeout: 30000,
-      // replaces remoteRoot with localRoot to get src files
-      localRoot: rtLibUtils._absApp(root, '.'),
-      remoteRoot: '/code',
-      outputCapture: 'std',
-      attachSimplePort: 0
-    }
-
-    const actionFileStats = fs.lstatSync(actionPath)
-    if (actionFileStats.isFile()) {
-      // why is this condition here?
-    }
-    config.runtimeArgs = [
-        `${packageName}/${an}`,
-        actionPath,
-        '-v'
-    ]
-    if (actionFileStats.isDirectory()) {
-      // take package.json.main or 'index.js'
-      const zipMain = rtLibUtils.getActionEntryFile(path.join(actionPath, 'package.json'))
-      config.runtimeArgs[1] = path.join(actionPath, zipMain)
-    }
-    if (action.annotations && action.annotations['require-adobe-auth'] && ow.apihost === 'https://adobeioruntime.net') {
-      // NOTE: The require-adobe-auth annotation is a feature implemented in the
-      // runtime plugin. The current implementation replaces the action by a sequence
-      // and renames the action to __secured_<action>. The annotation will soon be
-      // natively supported in Adobe I/O Runtime, at which point this condition won't
-      // be needed anymore.
-      /* instanbul ignore next */
-      config.runtimeArgs[0] = `${packageName}/__secured_${an}`
-    }
-    if (action.runtime) {
-      config.runtimeArgs.push('--kind')
-      config.runtimeArgs.push(action.runtime)
-    }
-    return config
-  })
-
-  return [actionConfigNames, actionConfigs]
-}
-
-/** @private */
-async function generateConfig (appConfig, props) {
-  const { web } = appConfig
-  const { hasFrontend, withBackend, frontEndUrl } = props
-
-  let actionConfigNames = []
-  let actionConfigs = []
-
-  if (withBackend) {
-    const modifiedConfig = cloneDeep(appConfig)
-    const packages = modifiedConfig.manifest.full.packages
-    const packagePlaceholder = modifiedConfig.manifest.packagePlaceholder
-    if (packages[packagePlaceholder]) {
-      packages[modifiedConfig.ow.package] = packages[packagePlaceholder]
-      delete packages[packagePlaceholder]
-    }
-
-    Object.keys(packages).forEach(pkg => {
-      const packageConfigs = processPackageActionConfigs(modifiedConfig, pkg, packages[pkg])
-      // merge the arrays
-      actionConfigNames = [...actionConfigNames, ...packageConfigs[0]]
-      actionConfigs = [...actionConfigs, ...packageConfigs[1]]
-    })
-  }
-
-  const debugConfig = {
-    configurations: actionConfigs,
-    compounds: [{
-      name: 'Actions',
-      configurations: actionConfigNames
-    }]
-  }
-
-  if (hasFrontend) {
-    debugConfig.configurations.push({
-      type: 'chrome',
-      request: 'launch',
-      name: 'Web',
-      url: frontEndUrl,
-      webRoot: web.src,
-      breakOnLoad: true,
-      sourceMapPathOverrides: {
-        '*': path.join(web.distDev, '*')
-      }
-    })
-    debugConfig.compounds.push({
-      name: 'WebAndActions',
-      configurations: ['Web'].concat(actionConfigNames)
-    })
-  }
-
-  return debugConfig
 }
 
 module.exports = (config) => ({

--- a/test/commands/lib/run-dev.test.js
+++ b/test/commands/lib/run-dev.test.js
@@ -38,7 +38,17 @@ const mockLogger = require('@adobe/aio-lib-core-logging')
 const logPoller = require('../../../src/lib/log-poller')
 const appHelper = require('../../../src/lib/app-helper')
 const execa = require('execa')
+const yeoman = require('yeoman-environment')
+const fs = require('fs-extra')
 
+const mockYeomanRegister = jest.fn()
+const mockYeomanRun = jest.fn()
+yeoman.createEnv.mockReturnValue({
+  register: mockYeomanRegister,
+  run: mockYeomanRun
+})
+
+jest.mock('yeoman-environment')
 jest.mock('execa')
 jest.mock('node-fetch')
 jest.mock('../../../src/lib/run-local-runtime')
@@ -110,6 +120,9 @@ beforeEach(() => {
   mockCleanup.serve.mockReset()
   mockCleanup.bundle.mockReset()
 
+  mockYeomanRun.mockReset()
+  mockYeomanRegister.mockReset()
+
   logPoller.run.mockImplementation(() => ({
     poller: {},
     cleanup: mockCleanup.logPoller
@@ -163,40 +176,6 @@ const OW_JAR_PATH = path.join(CLI_CONFIG.dataDir, 'openwhisk', 'standalone-v1', 
 const EXECA_LOCAL_OW_ARGS = ['java', expect.arrayContaining(['-jar', OW_JAR_PATH, '-m', OW_RUNTIMES_CONFIG, '--no-ui']), expect.anything()]
 
 /* ****************** Helpers ******************* */
-
-/** @private */
-const getExpectedUIVSCodeDebugConfig = uiPort => expect.objectContaining({
-  type: 'chrome',
-  request: 'launch',
-  name: 'Web',
-  url: `http://localhost:${uiPort}`,
-  webRoot: path.resolve('/web-src'),
-  breakOnLoad: true,
-  sourceMapPathOverrides: {
-    '*': path.resolve('/dist/web-src-dev/*')
-  }
-})
-
-const getExpectedActionVSCodeDebugConfig = (isLocal, actionName) => {
-  const envFile = isLocal ? path.join('dist', '.env.local') : '.env'
-  return expect.objectContaining({
-    type: 'pwa-node',
-    request: 'launch',
-    name: 'Action:' + actionName,
-    attachSimplePort: 0,
-    runtimeExecutable: path.resolve('/node_modules/.bin/wskdebug'),
-    runtimeArgs: [
-      actionName,
-      expect.stringContaining(actionName.split('/')[1]),
-      '-v',
-      '--kind',
-      'nodejs:12'
-    ],
-    envFile: path.join('${workspaceFolder}', envFile), // eslint-disable-line no-template-curly-in-string
-    localRoot: path.resolve('/'),
-    remoteRoot: '/code'
-  })
-}
 
 /** @private */
 async function loadEnvScripts (config, excludeFiles = [], customApp = false) {
@@ -454,12 +433,6 @@ function runCommonTests (ref) {
     expect(buildActions).toHaveBeenCalledTimes(0)
     expect(deployActions).toHaveBeenCalledTimes(0)
   })
-
-  test('should not set vscode config for actions if skipActions is set', async () => {
-    const options = { skipActions: true, devRemote: ref.devRemote }
-    await runDev([], ref.config, options)
-    expect(global.fakeFileSystem.files()['/.vscode/launch.json'].toString()).not.toEqual(expect.stringContaining('wskdebug'))
-  })
 }
 
 /** @private */
@@ -523,27 +496,6 @@ function runCommonBackendOnlyTests (ref) {
     const options = { devRemote: ref.devRemote }
     await runDev([], ref.config, options)
     expect(serve).toHaveBeenCalledTimes(0)
-  })
-
-  test('should generate a vscode config for actions only', async () => {
-    const options = { devRemote: ref.devRemote }
-    await runDev([], ref.config, options)
-    const isLocal = !ref.devRemote
-
-    let packageName = ref.config.ow.package
-    const packages = ref.config.manifest.full.packages
-    const packagePlaceholder = ref.config.manifest.packagePlaceholder
-    if (!packages[packagePlaceholder]) {
-      packageName = Object.keys(packages)[0]
-    }
-
-    expect(JSON.parse(global.fakeFileSystem.files()['/.vscode/launch.json'].toString())).toEqual(expect.objectContaining({
-      configurations: [
-        getExpectedActionVSCodeDebugConfig(isLocal, `${packageName}/action`),
-        getExpectedActionVSCodeDebugConfig(isLocal, `${packageName}/action-zip`)
-        // fails if ui config
-      ]
-    }))
   })
 }
 
@@ -627,6 +579,10 @@ describe('with local actions and frontend', () => {
       config: ref.config,
       cleanup: mockRunDevLocalCleanup
     }))
+
+    mockYeomanRun.mockImplementation(() => {
+      fs.writeFileSync('.vscode/launch.json', '')
+    })
   })
 
   runCommonTests(ref)
@@ -673,6 +629,10 @@ describe('with remote actions and no frontend (custom package)', () => {
     ref.devRemote = true
     ref.config = await loadEnvScripts(global.fakeConfig.tvm, ['/web-src/index.html'], /* custom package in manifest */ true)
     ref.appFiles = ['/manifest.yml', '/package.json', '/actions/action-zip/index.js', '/actions/action-zip/package.json', '/actions/action.js']
+
+    mockYeomanRun.mockImplementation(() => {
+      fs.writeFileSync('.vscode/launch.json', '')
+    })
   })
 
   runCommonTests(ref)
@@ -688,6 +648,10 @@ describe('with remote actions and no frontend', () => {
     ref.devRemote = true
     ref.config = await loadEnvScripts(global.fakeConfig.tvm, ['/web-src/index.html'])
     ref.appFiles = ['/manifest.yml', '/package.json', '/actions/action-zip/index.js', '/actions/action-zip/package.json', '/actions/action.js']
+
+    mockYeomanRun.mockImplementation(() => {
+      fs.writeFileSync('.vscode/launch.json', '')
+    })
   })
 
   runCommonTests(ref)
@@ -733,6 +697,10 @@ describe('with remote actions and frontend', () => {
     ref.devRemote = true
     ref.config = await loadEnvScripts(global.fakeConfig.tvm)
     ref.appFiles = ['/manifest.yml', '/package.json', '/web-src/index.html', '/web-src/src/config.json', '/actions/action-zip/index.js', '/actions/action-zip/package.json', '/actions/action.js']
+
+    mockYeomanRun.mockImplementation(() => {
+      fs.writeFileSync('.vscode/launch.json', '')
+    })
   })
 
   runCommonTests(ref)
@@ -764,25 +732,6 @@ describe('with remote actions and frontend', () => {
     await runDev([], ref.config, { skipActions: true })
     expect('/web-src/src/config.json' in global.fakeFileSystem.files()).toEqual(true)
     expect(JSON.parse(global.fakeFileSystem.files()['/web-src/src/config.json'].toString())).toEqual(retVal)
-  })
-
-  test('should generate a vscode debug config for actions and web-src', async () => {
-    const port = 9999
-    serve.mockImplementation(() => ({
-      url: `http://localhost:${port}`,
-      cleanup: jest.fn()
-    }))
-
-    const options = { devRemote: ref.devRemote }
-    await runDev([], ref.config, options)
-    const isLocal = !ref.devRemote
-    expect(JSON.parse(global.fakeFileSystem.files()['/.vscode/launch.json'].toString())).toEqual(expect.objectContaining({
-      configurations: [
-        getExpectedActionVSCodeDebugConfig(isLocal, 'sample-app-1.0.0/action'),
-        getExpectedActionVSCodeDebugConfig(isLocal, 'sample-app-1.0.0/action-zip'),
-        getExpectedUIVSCodeDebugConfig(port)
-      ]
-    }))
   })
 
   test('should inject local action urls into the UI', async () => {
@@ -819,6 +768,10 @@ describe('with frontend only', () => {
     // exclude manifest file = backend only (should we make a fixture app without actions/ as well?)
     ref.config = await loadEnvScripts(global.fakeConfig.tvm, ['/manifest.yml'])
     ref.appFiles = ['/package.json', '/web-src/index.html', '/web-src/src/config.json', '/actions/action-zip/index.js', '/actions/action-zip/package.json', '/actions/action.js'] // still have actions cause we only delete manifest.yml
+
+    mockYeomanRun.mockImplementation(() => {
+      fs.writeFileSync('.vscode/launch.json', '')
+    })
   })
 
   runCommonTests(ref)
@@ -856,128 +809,5 @@ describe('with frontend only', () => {
   test('should not run serve', async () => {
     await runDev([], ref.config, { skipServe: true })
     expect(serve).not.toHaveBeenCalled()
-  })
-
-  // Note: these tests can be safely deleted once the require-adobe-auth is
-  // natively supported in Adobe I/O Runtime.
-  test('vscode wskdebug config with require-adobe-auth annotation && apihost=https://adobeioruntime.net', async () => {
-  // create test app
-    global.addSampleAppFiles()
-    global.fakeFileSystem.removeKeys(['/web-src/index.html'])
-    mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
-    const devRemote = true
-    const config = loadConfig()
-    // avoid recreating a new fixture
-    config.manifest.package.actions.action.annotations = { 'require-adobe-auth': true }
-    config.ow.apihost = 'https://adobeioruntime.net'
-    const options = { devRemote }
-    await runDev([], config, options)
-
-    expect(JSON.parse(global.fakeFileSystem.files()['/.vscode/launch.json'].toString())).toEqual(expect.objectContaining({
-      configurations: expect.arrayContaining([
-        expect.objectContaining({
-          type: 'pwa-node',
-          request: 'launch',
-          name: 'Action:' + 'sample-app-1.0.0/action',
-          attachSimplePort: 0,
-          runtimeExecutable: path.resolve('/node_modules/.bin/wskdebug'),
-          runtimeArgs: [
-            'sample-app-1.0.0/__secured_action',
-            path.resolve('actions/action.js'),
-            '-v',
-            '--kind',
-            'nodejs:12'
-          ],
-          envFile: path.join('${workspaceFolder}', '.env'), // eslint-disable-line no-template-curly-in-string
-          localRoot: path.resolve('/'),
-          remoteRoot: '/code'
-        })
-      ])
-    }))
-  })
-
-  test('vscode wskdebug config with require-adobe-auth annotation && apihost!=https://adobeioruntime.net', async () => {
-    // create test app
-    global.addSampleAppFiles()
-    global.fakeFileSystem.removeKeys(['/web-src/index.html'])
-    mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
-    const devRemote = true
-    const config = loadConfig()
-    // avoid recreating a new fixture
-    config.manifest.package.actions.action.annotations = { 'require-adobe-auth': true }
-    config.ow.apihost = 'https://notadobeioruntime.net'
-    const options = { devRemote }
-    await runDev([], config, options)
-
-    expect(JSON.parse(global.fakeFileSystem.files()['/.vscode/launch.json'].toString())).toEqual(expect.objectContaining({
-      configurations: expect.arrayContaining([
-        expect.objectContaining({
-          type: 'pwa-node',
-          request: 'launch',
-          name: 'Action:' + 'sample-app-1.0.0/action',
-          attachSimplePort: 0,
-          runtimeExecutable: path.resolve('/node_modules/.bin/wskdebug'),
-          runtimeArgs: [
-            'sample-app-1.0.0/action',
-            path.resolve('actions/action.js'),
-            '-v',
-            '--kind',
-            'nodejs:12'
-          ],
-          envFile: path.join('${workspaceFolder}', '.env'), // eslint-disable-line no-template-curly-in-string
-          localRoot: path.resolve('/'),
-          remoteRoot: '/code'
-        })
-      ])
-    }))
-  })
-
-  test('vscode wskdebug config without runtime option', async () => {
-    // create test app
-    global.addSampleAppFiles()
-    global.fakeFileSystem.removeKeys(['/web-src/index.html'])
-    mockAIOConfig.get.mockReturnValue(global.fakeConfig.tvm)
-    const devRemote = true
-    const config = loadConfig()
-    // avoid recreating a new fixture
-    delete config.manifest.package.actions.action.runtime
-    const options = { devRemote }
-    await runDev([], config, options)
-
-    expect(JSON.parse(global.fakeFileSystem.files()['/.vscode/launch.json'].toString())).toEqual(expect.objectContaining({
-      configurations: expect.arrayContaining([
-        expect.objectContaining({
-          type: 'pwa-node',
-          request: 'launch',
-          name: 'Action:' + 'sample-app-1.0.0/action',
-          attachSimplePort: 0,
-          runtimeExecutable: path.resolve('/node_modules/.bin/wskdebug'),
-          runtimeArgs: [
-            'sample-app-1.0.0/action',
-            path.resolve('actions/action.js'),
-            '-v'
-            // no kind
-          ],
-          envFile: path.join('${workspaceFolder}', '.env'), // eslint-disable-line no-template-curly-in-string
-          localRoot: path.resolve('/'),
-          remoteRoot: '/code'
-        })
-      ])
-    }))
-  })
-
-  test('should generate a vscode config for ui only', async () => {
-    const port = 9999
-    serve.mockImplementation(() => ({
-      url: `http://localhost:${port}`,
-      cleanup: jest.fn()
-    }))
-
-    await runDev([], ref.config)
-    expect(JSON.parse(global.fakeFileSystem.files()['/.vscode/launch.json'].toString())).toEqual(expect.objectContaining({
-      configurations: [
-        getExpectedUIVSCodeDebugConfig(port)
-      ]
-    }))
   })
 })


### PR DESCRIPTION
- Fixes #362 
- [x] Needs https://github.com/adobe/generator-aio-app/pull/123 to be pulled in and released (**NOTE**: this is why the gh-actions will fail currently. See test block below for testing steps)

## How Has This Been Tested?

npm test
manual tests of `aio app run` (local and remote) with and without VS Code debugging


```
mkdir vscode-test
cd vscode-test

git clone https://github.com/adobe/generator-aio-app
cd generator-aio-app
git checkout vscode
npm i
cd ..

git clone https://github.com/adobe/aio-cli-plugin-app
cd aio-cli-plugin-app
git checkout vscode-gen
npm i
npm link ../generator-aio-app
aio plugins link .
cd ..

aio app run
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
