### PR TITLE
Do not propagate default tvm url config

### DIFF
--- a/src/lib/config-loader.js
+++ b/src/lib/config-loader.js
@@ -166,7 +166,9 @@ module.exports = () => {
   config.s3.folder = config.ow.namespace // this becomes the root only /
   // Legacy applications set the defaultTvmUrl in .env, so we need to ignore it to not
   // consider it as custom. The default will be set downstream by aio-lib-core-tvm.
-  config.s3.tvmUrl = userConfig.app.tvmurl === defaultTvmUrl ? undefined : userConfig.app.tvmurl
+  if (userConfig.app.tvmurl !== defaultTvmUrl) {
+    config.s3.tvmUrl = userConfig.app.tvmurl
+  }
   // set hostname for backend actions && UI
   config.app.defaultHostname = defaultAppHostname
   config.app.hostname = userConfig.app.hostname || defaultAppHostname

--- a/src/lib/config-loader.js
+++ b/src/lib/config-loader.js
@@ -164,7 +164,9 @@ module.exports = () => {
   config.ow.package = `${config.app.name}-${config.app.version}`
   // S3 static files deployment config
   config.s3.folder = config.ow.namespace // this becomes the root only /
-  config.s3.tvmUrl = userConfig.app.tvmurl || defaultTvmUrl
+  // Legacy applications set the defaultTvmUrl in .env, so we need to ignore it to not
+  // consider it as custom. The default will be set downstream by aio-lib-core-tvm.
+  config.s3.tvmUrl = userConfig.app.tvmurl === defaultTvmUrl ? undefined : userConfig.app.tvmurl
   // set hostname for backend actions && UI
   config.app.defaultHostname = defaultAppHostname
   config.app.hostname = userConfig.app.hostname || defaultAppHostname

--- a/test/commands/lib/config-loader.test.js
+++ b/test/commands/lib/config-loader.test.js
@@ -15,6 +15,7 @@ const loadConfig = require('../../../src/lib/config-loader')
 const mockAIOConfig = require('@adobe/aio-lib-core-config')
 const yaml = require('js-yaml')
 const chalk = require('chalk')
+const defaults = require('../../../src/lib/defaults')
 
 jest.mock('@adobe/aio-lib-core-logging')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:config-loader', { provider: 'debug' })
@@ -100,5 +101,35 @@ describe('load config', () => {
     expect(config.app.hostname).toEqual('some-other-host')
     expect(config.ow.defaultApihost).toEqual('https://adobeioruntime.net')
     expect(config.app.defaultHostname).toEqual('adobeio-static.net')
+  })
+
+  test('Tvm url config', () => {
+    // custom
+    mockAIOConfig.get.mockReturnValue({
+      ...global.fakeConfig.creds,
+      app: {
+        tvmurl: 'custom'
+      }
+    })
+    config = loadConfig()
+    expect(config.s3.tvmUrl).toEqual('custom')
+    // empty
+    mockAIOConfig.get.mockReturnValue({
+      ...global.fakeConfig.creds,
+      app: {
+        tvmurl: undefined
+      }
+    })
+    config = loadConfig()
+    expect(config.s3.tvmUrl).toEqual(undefined)
+    // default (should not set it)
+    mockAIOConfig.get.mockReturnValue({
+      ...global.fakeConfig.creds,
+      app: {
+        tvmurl: defaults.defaultTvmUrl
+      }
+    })
+    config = loadConfig()
+    expect(config.s3.tvmUrl).toEqual(undefined)
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

relates to https://github.com/adobe/aio-lib-web/pull/149 and https://github.com/adobe/aio-lib-core-tvm/pull/66/files

replaces https://github.com/adobe/aio-cli-plugin-app/pull/389/files

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
