### PR TITLE
Allow overriding of local openwhisk jvm args

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -288,8 +288,9 @@ function waitFor (t) {
 /** @private */
 async function runOpenWhiskJar (jarFile, runtimeConfigFile, apihost, waitInitTime, waitPeriodTime, timeout, /* istanbul ignore next */ execaOptions = {}) {
   aioLogger.debug(`runOpenWhiskJar - jarFile: ${jarFile} runtimeConfigFile ${runtimeConfigFile} apihost: ${apihost} waitInitTime: ${waitInitTime} waitPeriodTime: ${waitPeriodTime} timeout: ${timeout}`)
-  const proc = execa('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', jarFile, '-m', runtimeConfigFile, '--no-ui', '--disable-color-logging'], execaOptions)
-
+  const jvmArgs = process.env.AIO_OW_JVM_ARGS ? process.env.AIO_OW_JVM_ARGS.split(' ') : [];
+  const proc = execa('java', ['-jar', ...jvmArgs, '-Dwhisk.concurrency-limit.max=10', jarFile, '-m', runtimeConfigFile, '--no-ui', '--disable-color-logging'], execaOptions)
+  
   const endTime = Date.now() + timeout
   await waitFor(waitInitTime)
   await waitForOpenWhiskReadiness(apihost, endTime, waitPeriodTime, timeout, waitFor)

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -289,7 +289,7 @@ function waitFor (t) {
 async function runOpenWhiskJar (jarFile, runtimeConfigFile, apihost, waitInitTime, waitPeriodTime, timeout, /* istanbul ignore next */ execaOptions = {}) {
   aioLogger.debug(`runOpenWhiskJar - jarFile: ${jarFile} runtimeConfigFile ${runtimeConfigFile} apihost: ${apihost} waitInitTime: ${waitInitTime} waitPeriodTime: ${waitPeriodTime} timeout: ${timeout}`)
   const jvmArgs = process.env.AIO_OW_JVM_ARGS ? process.env.AIO_OW_JVM_ARGS.split(' ') : [];
-  const proc = execa('java', ['-jar', ...jvmArgs, '-Dwhisk.concurrency-limit.max=10', jarFile, '-m', runtimeConfigFile, '--no-ui', '--disable-color-logging'], execaOptions)
+  const proc = execa('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', ...jvmArgs, jarFile, '-m', runtimeConfigFile, '--no-ui', '--disable-color-logging'], execaOptions)
   
   const endTime = Date.now() + timeout
   await waitFor(waitInitTime)

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -26,6 +26,7 @@ beforeEach(() => {
   fetch.mockReset()
   config.get.mockReset()
   config.set.mockReset()
+  delete process.env.AIO_OW_JVM_ARGS
 })
 
 test('isDockerRunning', async () => {
@@ -520,13 +521,28 @@ test('runOpenWhiskJar ok', async () => {
   fetch.mockReturnValue({ ok: true })
   execa.mockReturnValue({ stdout: jest.fn() })
 
-  const result = appHelper.runOpenWhiskJar()
+  const result = appHelper.runOpenWhiskJar('jar', 'conf')
 
   await expect(result).resolves.toEqual({
     proc: expect.any(Object)
   })
   expect(fetch).toHaveBeenCalledTimes(1)
-  expect(execa).toHaveBeenCalledTimes(1)
+  expect(execa).toHaveBeenCalledWith('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', 'jar', '-m', 'conf', '--no-ui', '--disable-color-logging'], {});
+})
+
+test('runOpenWhiskJar with AIO_OW_JVM_ARGS env var is passed to execa', async () => {
+  fetch.mockReturnValue({ ok: true })
+  execa.mockReturnValue({ stdout: jest.fn() })
+
+  process.env.AIO_OW_JVM_ARGS = 'arg1 arg2'
+
+  const result = appHelper.runOpenWhiskJar('jar', 'conf')
+
+  await expect(result).resolves.toEqual({
+    proc: expect.any(Object)
+  })
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(execa).toHaveBeenCalledWith('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', 'arg1', 'arg2', 'jar', '-m', 'conf', '--no-ui', '--disable-color-logging'], {});
 })
 
 test('waitForOpenWhiskReadiness timeout', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows the user to override the parameters passed to the local openwhisk instance.
This can be used to override default configuration parameters.

*Example Usage*

If you have a function that requires more memory than the 512M default:

```bash
AIO_OW_JVM_ARGS="-Dwhisk.memory.max=1024M" aio app:run --local
```

## Motivation and Context

Testing functions locally using the same resource configs as in the Adobe IO Runtime environment was not possible without modifying vendored code.

## How Has This Been Tested?

Tested locally using the `aio` cli.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
