### PR TITLE
fix: ACNA-1026 - aio app test is failing on EBADF bad file descriptor (Windows only)

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -62,7 +62,7 @@ async function runPackageScript (scriptName, dir, cmdArgs = []) {
       command = `${command} ${cmdArgs.join(' ')}`
     }
 
-    // we have to disable ipc for Windows (see link in debug line below)
+    // we have to disable IPC for Windows (see link in debug line below)
     const isWindows = process.platform === 'win32'
     const ipc = isWindows ? null : 'ipc'
 
@@ -76,24 +76,24 @@ async function runPackageScript (scriptName, dir, cmdArgs = []) {
     if (isWindows) {
       aioLogger.debug(`os is Windows, so we can't use ipc when running npm script ${scriptName}`)
       aioLogger.debug('see: https://github.com/adobe/aio-cli-plugin-app/issues/372')
-    } else {
-      // handle IPC from possible aio-run-detached script
-      child.on('message', message => {
-        if (message.type === 'long-running-process') {
-          const { pid, logs } = message.data
-          aioLogger.debug(`Found ${scriptName} event hook long running process (pid: ${pid}). Registering for SIGTERM`)
-          aioLogger.debug(`Log locations for ${scriptName} event hook long-running process (stdout: ${logs.stdout} stderr: ${logs.stderr})`)
-          process.on('exit', () => {
-            try {
-              aioLogger.debug(`Killing ${scriptName} event hook long-running process (pid: ${pid})`)
-              process.kill(pid, 'SIGTERM')
-            } catch (_) {
-            // do nothing if pid not found
-            }
-          })
-        }
-      })
     }
+
+    // handle IPC from possible aio-run-detached script
+    child.on('message', message => {
+      if (message.type === 'long-running-process') {
+        const { pid, logs } = message.data
+        aioLogger.debug(`Found ${scriptName} event hook long running process (pid: ${pid}). Registering for SIGTERM`)
+        aioLogger.debug(`Log locations for ${scriptName} event hook long-running process (stdout: ${logs.stdout} stderr: ${logs.stderr})`)
+        process.on('exit', () => {
+          try {
+            aioLogger.debug(`Killing ${scriptName} event hook long-running process (pid: ${pid})`)
+            process.kill(pid, 'SIGTERM')
+          } catch (_) {
+            // do nothing if pid not found
+          }
+        })
+      }
+    })
     return child
   } else {
     aioLogger.debug(`${dir} does not contain a package.json or it does not contain a script named ${scriptName}`)

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -61,28 +61,39 @@ async function runPackageScript (scriptName, dir, cmdArgs = []) {
     if (cmdArgs.length) {
       command = `${command} ${cmdArgs.join(' ')}`
     }
+
+    // we have to disable ipc for Windows (see link in debug line below)
+    const isWindows = process.platform === 'win32'
+    const ipc = isWindows ? null : 'ipc'
+
     const child = execa.command(command, {
-      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+      stdio: ['inherit', 'inherit', 'inherit', ipc],
       shell: true,
       cwd: dir,
       preferLocal: true
     })
-    // handle IPC from possible aio-run-detached script
-    child.on('message', message => {
-      if (message.type === 'long-running-process') {
-        const { pid, logs } = message.data
-        aioLogger.debug(`Found ${scriptName} event hook long running process (pid: ${pid}). Registering for SIGTERM`)
-        aioLogger.debug(`Log locations for ${scriptName} event hook long-running process (stdout: ${logs.stdout} stderr: ${logs.stderr})`)
-        process.on('exit', () => {
-          try {
-            aioLogger.debug(`Killing ${scriptName} event hook long-running process (pid: ${pid})`)
-            process.kill(pid, 'SIGTERM')
-          } catch (_) {
+
+    if (isWindows) {
+      aioLogger.debug(`os is Windows, so we can't use ipc when running npm script ${scriptName}`)
+      aioLogger.debug('see: https://github.com/adobe/aio-cli-plugin-app/issues/372')
+    } else {
+      // handle IPC from possible aio-run-detached script
+      child.on('message', message => {
+        if (message.type === 'long-running-process') {
+          const { pid, logs } = message.data
+          aioLogger.debug(`Found ${scriptName} event hook long running process (pid: ${pid}). Registering for SIGTERM`)
+          aioLogger.debug(`Log locations for ${scriptName} event hook long-running process (stdout: ${logs.stdout} stderr: ${logs.stderr})`)
+          process.on('exit', () => {
+            try {
+              aioLogger.debug(`Killing ${scriptName} event hook long-running process (pid: ${pid})`)
+              process.kill(pid, 'SIGTERM')
+            } catch (_) {
             // do nothing if pid not found
-          }
-        })
-      }
-    })
+            }
+          })
+        }
+      })
+    }
     return child
   } else {
     aioLogger.debug(`${dir} does not contain a package.json or it does not contain a script named ${scriptName}`)


### PR DESCRIPTION
Fixes #372 
Note that because of this fix, killing of `aio-run-detached` processes will not work on Windows, until this node bug is fixed.

## How Has This Been Tested?

npm test
- [X] test on Windows
- [x] test on Linux
- [x] test on macOS

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
