### PR TITLE
inform user if no actions were built

### DIFF
--- a/test/__mocks__/ora.js
+++ b/test/__mocks__/ora.js
@@ -10,26 +10,29 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const spinner = {
+  stopAndPersist: jest.fn(() => {
+    // console.error('stopAndPersist')
+  }),
+  stop: jest.fn((value) => {
+    console.error(value)
+  }),
+  start: jest.fn((value) => {
+    console.error(value)
+  }),
+  warn: jest.fn((value) => {
+    console.error(value)
+  }),
+  info: jest.fn((msg) => {
+    console.log(msg)
+  }),
+  error: jest.fn(),
+  fail: jest.fn(),
+  succeed: jest.fn((value) => {
+    console.error(value)
+  })
+}
+
 module.exports = () => {
-  const spinner = {
-    stopAndPersist: jest.fn(() => {
-      // console.error('stopAndPersist')
-    }),
-    stop: jest.fn(),
-    start: jest.fn(() => {
-      // console.error('start')
-    }),
-    warn: jest.fn(() => {
-      // console.error('warn')
-    }),
-    info: jest.fn((msg) => {
-      console.log(msg)
-    }),
-    error: jest.fn(),
-    fail: jest.fn(),
-    succeed: jest.fn(() => {
-      // console.error('succeed')
-    })
-  }
   return spinner
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- if no actions match the -a flag, a message is displayed that shows this ( #444 )
- added aioLogger debug info describing what was built
- re-ordered some logic to prevent spinner/aioLogger output from becoming interlaced
- output message if building of action was skipped because of a 'build-actions' hook

## Related Issue
#444 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screen Shot 2021-07-30 at 3 03 02 PM](https://user-images.githubusercontent.com/46134/127715936-930d421b-f42f-4cf5-94ae-e89e1757fffe.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
