### PR TITLE
Fix CI/CD deploy error

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -379,15 +379,24 @@ function setOrgServicesConfig (supportedServices) {
  * @returns {object} op['view'] metadata OR null
  */
 async function buildExcShellViewExtensionMetadata (libConsoleCLI, aioConfig) {
-  const serviceProperties = await libConsoleCLI.getServicePropertiesFromWorkspace(
-    aioConfig.project.org.id,
-    aioConfig.project.id,
-    aioConfig.project.workspace
-  )
-  const services = serviceProperties.map(s => ({
-    name: s.name,
-    code: s.sdkCode
-  }))
+  let serviceProperties
+  let services
+  if (aioConfig.project.workspace.details) {
+    serviceProperties = aioConfig.project.workspace.details.services
+  }
+  if (serviceProperties) {
+    services = (Array.isArray(serviceProperties)) ? serviceProperties : JSON.parse(serviceProperties)
+  } else {
+    serviceProperties = await libConsoleCLI.getServicePropertiesFromWorkspace(
+      aioConfig.project.org.id,
+      aioConfig.project.id,
+      aioConfig.project.workspace
+    )
+    services = serviceProperties.map(s => ({
+      name: s.name,
+      code: s.sdkCode
+    }))
+  }
   return {
     services: Object.assign([], services),
     profile: {

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -571,7 +571,7 @@ test('setOrgServicesConfig', () => {
 })
 
 describe('buildExcShellViewExtensionMetadata', () => {
-  test('with service properties', async () => {
+  test('with service properties from console', async () => {
     const mockConsoleCLIInstance = {
       getServicePropertiesFromWorkspace: jest.fn()
     }
@@ -603,6 +603,91 @@ describe('buildExcShellViewExtensionMetadata', () => {
       }
     })
     expect(mockConsoleCLIInstance.getServicePropertiesFromWorkspace).toHaveBeenCalledWith('hola', 'bonjour', { id: 'yay', name: 'yo' })
+  })
+
+  test('with service properties in config', async () => {
+    const mockConsoleCLIInstance = {
+      getServicePropertiesFromWorkspace: jest.fn()
+    }
+    const mockAIOConfig = {
+      project: {
+        org: {
+          id: 'hola'
+        },
+        workspace: {
+          id: 'yay',
+          name: 'yo',
+          details: {
+            services: [
+              {
+                code: 'service1code',
+                name: 'service1'
+              },
+              {
+                code: 'service2code',
+                name: 'service2'
+              }
+            ]
+          }
+        },
+        id: 'bonjour'
+      }
+    }
+    const res = await appHelper.buildExcShellViewExtensionMetadata(mockConsoleCLIInstance, mockAIOConfig)
+    expect(res).toEqual({
+      services: [
+        { name: 'service1', code: 'service1code' },
+        { name: 'service2', code: 'service2code' }
+      ],
+      profile: {
+        client_id: 'firefly-app',
+        scope: 'ab.manage,additional_info.job_function,additional_info.projectedProductContext,additional_info.roles,additional_info,AdobeID,adobeio_api,adobeio.appregistry.read,audiencemanager_api,creative_cloud,mps,openid,read_organizations,read_pc.acp,read_pc.dma_tartan,read_pc,session'
+      }
+    })
+    expect(mockConsoleCLIInstance.getServicePropertiesFromWorkspace).toHaveBeenCalledTimes(0)
+  })
+
+  test('with service properties set as string', async () => {
+    const services = JSON.stringify([
+      {
+        code: 'service1code',
+        name: 'service1'
+      },
+      {
+        code: 'service2code',
+        name: 'service2'
+      }
+    ])
+    const mockConsoleCLIInstance = {
+      getServicePropertiesFromWorkspace: jest.fn()
+    }
+    const mockAIOConfig = {
+      project: {
+        org: {
+          id: 'hola'
+        },
+        workspace: {
+          id: 'yay',
+          name: 'yo',
+          details: {
+            services: services
+          }
+        },
+        id: 'bonjour'
+      }
+    }
+    const res = await appHelper.buildExcShellViewExtensionMetadata(mockConsoleCLIInstance, mockAIOConfig)
+    expect(res).toEqual({
+      services: [
+        { name: 'service1', code: 'service1code' },
+        { name: 'service2', code: 'service2code' }
+      ],
+      profile: {
+        client_id: 'firefly-app',
+        scope: 'ab.manage,additional_info.job_function,additional_info.projectedProductContext,additional_info.roles,additional_info,AdobeID,adobeio_api,adobeio.appregistry.read,audiencemanager_api,creative_cloud,mps,openid,read_organizations,read_pc.acp,read_pc.dma_tartan,read_pc,session'
+      }
+    })
+    expect(mockConsoleCLIInstance.getServicePropertiesFromWorkspace).toHaveBeenCalledTimes(0)
   })
 })
 


### PR DESCRIPTION
Helps in fixing [https://github.com/adobe/aio-apps-action/issues/10](https://github.com/adobe/aio-apps-action/issues/10)
For CI/CD deploy, the generated JWT token doesn't have scopes to get services details for a workspace. 
These details can be set as env var to avoid the API call, but while reading we need to convert them to JSON objects for further processing.
Following changes help support this. 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests and manual test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
