### PR TITLE
fix: app run & deploy messages should differentiate between web action and non-web action URLs

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -19,7 +19,7 @@ const BaseCommand = require('../../BaseCommand')
 const BuildCommand = require('./build')
 const webLib = require('@adobe/aio-lib-web')
 const { flags } = require('@oclif/command')
-const { runScript, buildExtensionPointPayloadWoMetadata, buildExcShellViewExtensionMetadata } = require('../../lib/app-helper')
+const { createWebExportFilter, runScript, buildExtensionPointPayloadWoMetadata, buildExcShellViewExtensionMetadata } = require('../../lib/app-helper')
 const rtLib = require('@adobe/aio-lib-runtime')
 
 class Deploy extends BuildCommand {
@@ -154,9 +154,22 @@ class Deploy extends BuildCommand {
       // log deployed resources
       if (deployedRuntimeEntities.actions) {
         this.log(chalk.blue(chalk.bold('Your deployed actions:')))
-        deployedRuntimeEntities.actions.forEach(a => {
-          this.log(chalk.blue(chalk.bold(`  -> ${a.url || a.name} `)))
-        })
+        const web = deployedRuntimeEntities.actions.filter(createWebExportFilter(true))
+        const nonWeb = deployedRuntimeEntities.actions.filter(createWebExportFilter(false))
+  
+        if (web.length > 0) {
+          this.log('web actions:')
+          web.forEach(a => {
+            this.log(chalk.blue(chalk.bold(`  -> ${a.url || a.name} `)))
+          })
+        }
+  
+        if (nonWeb.length > 0) {
+          this.log('non-web actions:')
+          nonWeb.forEach(a => {
+            this.log(chalk.blue(chalk.bold(`  -> ${a.url || a.name} `)))
+          })
+        }
       }
       // TODO urls should depend on extension point, exc shell only for exc shell extension point - use a post-app-deploy hook ?
       if (deployedFrontendUrl) {

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -156,14 +156,14 @@ class Deploy extends BuildCommand {
         this.log(chalk.blue(chalk.bold('Your deployed actions:')))
         const web = deployedRuntimeEntities.actions.filter(createWebExportFilter(true))
         const nonWeb = deployedRuntimeEntities.actions.filter(createWebExportFilter(false))
-  
+
         if (web.length > 0) {
           this.log('web actions:')
           web.forEach(a => {
             this.log(chalk.blue(chalk.bold(`  -> ${a.url || a.name} `)))
           })
         }
-  
+
         if (nonWeb.length > 0) {
           this.log('non-web actions:')
           nonWeb.forEach(a => {

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -483,7 +483,22 @@ function deleteUserConfig (configData) {
   fs.writeFileSync(configData.file, yaml.safeDump(phyConfig))
 }
 
+/** @private */
+const createWebExportFilter = (filterValue) => {
+  return (action) => {
+    if (!action && !action.body && !action.body.annotations) {
+      return false
+    }
+
+    const weAnnotation = action.body.annotations.filter(a => a.key === 'web-export')
+    const weValue = (weAnnotation.length > 0) ? !!(weAnnotation[0].value) : false
+
+    return (filterValue === weValue)
+  }
+}
+
 module.exports = {
+  createWebExportFilter,
   isNpmInstalled,
   isGitInstalled,
   installPackages,

--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -486,7 +486,7 @@ function deleteUserConfig (configData) {
 /** @private */
 const createWebExportFilter = (filterValue) => {
   return (action) => {
-    if (!action && !action.body && !action.body.annotations) {
+    if (!action || !action.body || !action.body.annotations) {
       return false
     }
 

--- a/src/lib/deploy-actions.js
+++ b/src/lib/deploy-actions.js
@@ -27,9 +27,22 @@ module.exports = async (config, isLocal = false, log = () => {}) => {
   if (!script) {
     const entities = await deployActions(config, { isLocalDev: isLocal }, log)
     if (entities.actions) {
-      entities.actions.forEach(a => {
-        log(`  -> ${a.url || a.name}`)
-      })
+      const web = entities.actions.filter(utils.createWebExportFilter(true))
+      const nonWeb = entities.actions.filter(utils.createWebExportFilter(false))
+
+      if (web.length > 0) {
+        log('web actions:')
+        web.forEach(a => {
+          log(`  -> ${a.url || a.name}`)
+        })
+      }
+
+      if (nonWeb.length > 0) {
+        log('non-web actions:')
+        nonWeb.forEach(a => {
+          log(`  -> ${a.url || a.name}`)
+        })
+      }
     }
   }
   utils.runScript(config.hooks['post-app-deploy'])

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -100,9 +100,11 @@ beforeEach(() => {
   helpers.runScript.mockReset()
   helpers.buildExtensionPointPayloadWoMetadata.mockReset()
   helpers.buildExcShellViewExtensionMetadata.mockReset()
+  helpers.createWebExportFilter.mockReset()
   jest.restoreAllMocks()
 
   helpers.wrapError.mockImplementation(msg => msg)
+  helpers.createWebExportFilter.mockImplementation(value => (() => value))
 })
 
 test('exports', async () => {

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -113,7 +113,6 @@ beforeEach(() => {
   helpers.buildExtensionPointPayloadWoMetadata.mockReset()
   helpers.buildExcShellViewExtensionMetadata.mockReset()
   helpers.createWebExportFilter.mockReset()
-  helpers.createWebExportFilter.mockReset()
 
   jest.restoreAllMocks()
 

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -778,3 +778,85 @@ describe('getCliInfo', () => {
     )
   })
 })
+
+describe('createWebExportFilter', () => {
+  const webFilter = appHelper.createWebExportFilter(true)
+  const nonWebFilter = appHelper.createWebExportFilter(false)
+
+  test('no web-export annotation', () => {
+    const action = {
+      name: 'abcde', url: 'https://fake.site', body: { annotations: [] }
+    }
+
+    expect(webFilter(action)).toEqual(false)
+    expect(nonWebFilter(action)).toEqual(true)
+  })
+
+  test('web-export:(true or truthy) annotation', () => {
+    const action1 = {
+      name: 'abcde',
+      url: 'https://fake.site',
+      body: {
+        annotations: [
+          {
+            key: 'web-export',
+            value: true
+          }
+        ]
+      }
+    }
+
+    expect(webFilter(action1)).toEqual(true)
+    expect(nonWebFilter(action1)).toEqual(false)
+
+    const action2 = {
+      name: 'abcde',
+      url: 'https://fake.site',
+      body: {
+        annotations: [
+          {
+            key: 'web-export',
+            value: 1
+          }
+        ]
+      }
+    }
+
+    expect(webFilter(action2)).toEqual(true)
+    expect(nonWebFilter(action2)).toEqual(false)
+  })
+
+  test('web-export:(false or falsy) annotation', () => {
+    const action1 = {
+      name: 'abcde',
+      url: 'https://fake.site',
+      body: {
+        annotations: [
+          {
+            key: 'web-export',
+            value: false
+          }
+        ]
+      }
+    }
+
+    expect(webFilter(action1)).toEqual(false)
+    expect(nonWebFilter(action1)).toEqual(true)
+
+    const action2 = {
+      name: 'abcde',
+      url: 'https://fake.site',
+      body: {
+        annotations: [
+          {
+            key: 'web-export',
+            value: null
+          }
+        ]
+      }
+    }
+
+    expect(webFilter(action2)).toEqual(false)
+    expect(nonWebFilter(action2)).toEqual(true)
+  })
+})

--- a/test/commands/lib/deploy-actions.test.js
+++ b/test/commands/lib/deploy-actions.test.js
@@ -13,8 +13,20 @@ governing permissions and limitations under the License.
 const deployActions = require('../../../src/lib/deploy-actions')
 const utils = require('../../../src/lib/app-helper')
 const { deployActions: rtDeployActions } = require('@adobe/aio-lib-runtime')
+const appHelperActual = jest.requireActual('../../../src/lib/app-helper')
 
 jest.mock('../../../src/lib/app-helper')
+
+const createWebExportAnnotation = (value) => ({
+  body: {
+    annotations: [
+      {
+        key: 'web-export',
+        value
+      }
+    ]
+  }
+})
 
 beforeEach(() => {
   utils.runScript.mockReset()
@@ -22,8 +34,8 @@ beforeEach(() => {
 
   rtDeployActions.mockReset()
   rtDeployActions.mockImplementation(() => ({}))
-  
-  utils.createWebExportFilter.mockImplementation(value => (() => true))
+
+  utils.createWebExportFilter.mockImplementation(filterValue => appHelperActual.createWebExportFilter(filterValue))
 })
 
 test('exports', () => {
@@ -74,16 +86,38 @@ test('use default parameters (coverage)', async () => {
   expect(utils.runScript).toHaveBeenNthCalledWith(3, undefined) // post-app-deploy
 })
 
-test('should log actions url or name when actions are deployed', async () => {
+test('should log actions url or name when actions are deployed (web-export: true)', async () => {
   rtDeployActions.mockResolvedValue({
     actions: [
-      { name: 'pkg/action', url: 'https://fake.com/action' },
-      { name: 'pkg/actionNoUrl' }
+      { name: 'pkg/action', url: 'https://fake.com/action', ...createWebExportAnnotation(true) },
+      { name: 'pkg/actionNoUrl', ...createWebExportAnnotation(true) }
     ]
   })
   const log = jest.fn()
   await deployActions({ hooks: {} }, false, log)
 
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('web actions:'))
   expect(log).toHaveBeenCalledWith(expect.stringContaining('https://fake.com/action'))
   expect(log).toHaveBeenCalledWith(expect.stringContaining('pkg/actionNoUrl'))
+})
+
+test('should log actions url or name when actions are deployed (web-export: false)', async () => {
+  rtDeployActions.mockResolvedValue({
+    actions: [
+      { name: 'pkg/action', url: 'https://fake.com/action', ...createWebExportAnnotation(false) },
+      { name: 'pkg/actionNoUrl', ...createWebExportAnnotation(false) }
+    ]
+  })
+  const log = jest.fn()
+  await deployActions({ hooks: {} }, false, log)
+
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('non-web actions:'))
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('https://fake.com/action'))
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('pkg/actionNoUrl'))
+
+  log.mockReset()
+  await deployActions({ hooks: {} }, false) // empty logger
+  expect(log).not.toHaveBeenCalledWith(expect.stringContaining('non-web actions:'))
+  expect(log).not.toHaveBeenCalledWith(expect.stringContaining('https://fake.com/action'))
+  expect(log).not.toHaveBeenCalledWith(expect.stringContaining('pkg/actionNoUrl'))
 })

--- a/test/commands/lib/deploy-actions.test.js
+++ b/test/commands/lib/deploy-actions.test.js
@@ -18,8 +18,12 @@ jest.mock('../../../src/lib/app-helper')
 
 beforeEach(() => {
   utils.runScript.mockReset()
+  utils.createWebExportFilter.mockReset()
+
   rtDeployActions.mockReset()
   rtDeployActions.mockImplementation(() => ({}))
+  
+  utils.createWebExportFilter.mockImplementation(value => (() => true))
 })
 
 test('exports', () => {


### PR DESCRIPTION
Fixes #436


## How Has This Been Tested?

npm test

## Screenshots (if appropriate):
`aio app deploy`
<img width="631" alt="Screen Shot 2021-08-04 at 9 55 04 PM" src="https://user-images.githubusercontent.com/36107/128197699-8c69b21f-7126-4fbe-8ee8-bbc82cc8a498.png">

`aio app run`
<img width="644" alt="Screen Shot 2021-08-04 at 9 55 19 PM" src="https://user-images.githubusercontent.com/36107/128197762-664cad4f-2e64-41d4-8893-3231dc371f7e.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
