### PR TITLE
[ACNA-1107] Omit old logs while continuous logs fetching

### DIFF
--- a/src/commands/app/logs.js
+++ b/src/commands/app/logs.js
@@ -78,7 +78,10 @@ class Logs extends BaseCommand {
 
     try {
       const owConfig = { ow: Object.values(fullConfig.all)[0].ow }
-      await rtLib.printActionLogs(owConfig, this.log, flags.limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch)
+      const tail = flags.poll || flags.tail || flags.watch
+      const startTime = tail ? Date.now() : 0
+
+      await rtLib.printActionLogs(owConfig, this.log, flags.limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch, undefined, startTime)
     } catch (error) {
       this.error(wrapError(error))
     }

--- a/src/commands/app/logs.js
+++ b/src/commands/app/logs.js
@@ -81,7 +81,7 @@ class Logs extends BaseCommand {
       const tail = flags.poll || flags.tail || flags.watch
       const startTime = tail ? Date.now() : 0
 
-      await rtLib.printActionLogs(owConfig, this.log, flags.limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch, undefined, startTime)
+      await rtLib.printActionLogs(owConfig, this.log, flags.limit, filterActions, flags.strip, tail, undefined, startTime)
     } catch (error) {
       this.error(wrapError(error))
     }

--- a/test/commands/app/logs.test.js
+++ b/test/commands/app/logs.test.js
@@ -26,6 +26,7 @@ jest.mock('../../../src/lib/app-helper.js')
 const helpers = require('../../../src/lib/app-helper.js')
 
 const mockRuntimeLib = require('@adobe/aio-lib-runtime')
+const RuntimeLib = require('@adobe/aio-lib-runtime')
 const printActionLogs = mockRuntimeLib.printActionLogs
 
 describe('interface', () => {
@@ -74,7 +75,7 @@ describe('run', () => {
     await command.run()
     const ow = owConfig()
     const actionList = ['legacy-app-1.0.0/action', 'legacy-app-1.0.0/action-zip']
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -86,7 +87,7 @@ describe('run', () => {
     expect(command.log).toHaveBeenCalledWith(expect.stringContaining('using --limit=1'))
     const ow = owConfig()
     const actionList = ['legacy-app-1.0.0/action', 'legacy-app-1.0.0/action-zip']
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -98,7 +99,7 @@ describe('run', () => {
     expect(command.log).toHaveBeenCalledWith(expect.stringContaining('using --limit=50'))
     const ow = owConfig()
     const actionList = ['legacy-app-1.0.0/action', 'legacy-app-1.0.0/action-zip']
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 50, actionList, false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 50, actionList, false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -109,7 +110,7 @@ describe('run', () => {
     await command.run()
     const ow = owConfig()
     const actionList = ['legacy-app-1.0.0/action', 'legacy-app-1.0.0/action-zip']
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 32, actionList, false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 32, actionList, false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -120,7 +121,7 @@ describe('run', () => {
     await command.run()
     const ow = owConfig()
     const actionList = ['legacy-app-1.0.0/action-zip']
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -139,7 +140,7 @@ describe('run', () => {
     await command.run()
     const ow = owConfig()
     const actionList = ['legacy-app-1.0.0/action']
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, actionList, false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -149,7 +150,7 @@ describe('run', () => {
 
     await command.run()
     const ow = owConfig()
-    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, ['pkg1/hello', '/actionwithoutpkg'], false, false)
+    expect(printActionLogs).toHaveBeenCalledWith({ ow }, command.log, 1, ['pkg1/hello', '/actionwithoutpkg'], false, false, undefined, expect.anything())
     expect(command.error).not.toHaveBeenCalled()
   })
 
@@ -172,5 +173,14 @@ describe('run', () => {
     command.getFullConfig.mockReturnValue(command.appConfig)
 
     await expect(command.run()).rejects.toEqual(new Error('There are no backend implementations for this project folder.'))
+  })
+  test('startTime is now when fetching continuously', () => {
+    const mockedNow = 1487076708000
+    Date.now = jest.fn(() => mockedNow)
+    command.argv = ['-t']
+    return command.run()
+      .then(() => {
+        expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, 1487076708000)
+      })
   })
 })

--- a/test/commands/app/logs.test.js
+++ b/test/commands/app/logs.test.js
@@ -26,7 +26,6 @@ jest.mock('../../../src/lib/app-helper.js')
 const helpers = require('../../../src/lib/app-helper.js')
 
 const mockRuntimeLib = require('@adobe/aio-lib-runtime')
-const RuntimeLib = require('@adobe/aio-lib-runtime')
 const printActionLogs = mockRuntimeLib.printActionLogs
 
 describe('interface', () => {
@@ -180,7 +179,7 @@ describe('run', () => {
     command.argv = ['-t']
     return command.run()
       .then(() => {
-        expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, 1487076708000)
+        expect(printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, 1487076708000)
       })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`startTime` is being used to filter out the logs to be printed.
While `--tail` or any other continuously fetching param, it should only fetch logs since `Date.now()`.

<!--- Describe your changes in detail -->

## Related Issue
Fixes #385

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Prerequisites: aio cli installed & a firefly project.

Steps: 
1. cd into the generated firefly project. 
2. run `aio app logs --tail`.
3. While `aio app logs --tail` is running, generate some logs via the firefly app.
Expected: Only logs following the `aio app logs --tail` should be printed.  

Steps: 
1. cd  firefly project.
2. run `aio app logs`
Expected: Logs prior to `aio app logs` should be printed. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
