### PR TITLE
parameterize extensions

### DIFF
--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -136,8 +136,12 @@ class InitCommand extends BaseCommand {
     if (!flags.extensions) {
       return [implPromptChoices.find(i => i.value.name === 'application').value]
     } else if (flags.extension) {
-      return implPromptChoices.filter(i => flags.extension.indexOf(i.value.name) > -1)
+      const extList = implPromptChoices.filter(i => flags.extension.indexOf(i.value.name) > -1)
         .map(i => i.value)
+      if (extList.length < 1) {
+        throw new Error(`--extension=${flags.extension} not found.`)
+      }
+      return extList
     } else {
       const choices = cloneDeep(implPromptChoices).filter(i => i.value.name !== 'application')
 

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -178,6 +178,9 @@ describe('bad args/flags', () => {
   test('--no-login and --workspace', async () => {
     await expect(TheCommand.run(['--no-login', '--workspace', 'dev'])).rejects.toThrow('--no-login and --workspace flags cannot be used together.')
   })
+  test('--no-login and --extension does not exist', async () => {
+    await expect(TheCommand.run(['--no-login', '--extension', 'dev'])).rejects.toThrow('--extension=dev not found.')
+  })
 })
 
 describe('run', () => {


### PR DESCRIPTION
## Description
We have some dialog input that is not easily automated for e2e/integration tests.  This pr adds a --extension:String flag to allow easy testing.

currently --extension is expected to be one ( or more ) of [`dx/asset-compute/worker/1`, `dx/excshell/1`, `application`]

## Related Issue
https://jira.corp.adobe.com/browse/ACNA-1271


## How Has This Been Tested?

with tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
