### PR TITLE
[ACNA-1304] Filter actions deployments. 

### DIFF
--- a/src/lib/build-actions.js
+++ b/src/lib/build-actions.js
@@ -19,10 +19,11 @@ const { buildActions } = require('@adobe/aio-lib-runtime')
  * @param {object} config see src/lib/config-loader.js
  */
 module.exports = async (config) => {
+  const { filterActions } = config || {}
   utils.runScript(config.hooks['pre-app-build'])
   const script = await utils.runScript(config.hooks['build-actions'])
   if (!script) {
-    await buildActions(config)
+    await buildActions(config, filterActions)
   }
   utils.runScript(config.hooks['post-app-build'])
 }

--- a/src/lib/deploy-actions.js
+++ b/src/lib/deploy-actions.js
@@ -25,8 +25,13 @@ module.exports = async (config, isLocal = false, log = () => {}) => {
   utils.runScript(config.hooks['pre-app-deploy'])
   const script = await utils.runScript(config.hooks['deploy-actions'])
   if (!script) {
-    const entities = await deployActions(config, { isLocalDev: isLocal }, log)
+    const deployConfig = {
+      isLocalDev: isLocal,
+      filterEntities: config.filterActions ? { actions: config.filterActions } : undefined
+    }
+    const entities = await deployActions(config, deployConfig, log)
     if (entities.actions) {
+      console.log('deployed', entities.actions)
       const web = entities.actions.filter(utils.createWebExportFilter(true))
       const nonWeb = entities.actions.filter(utils.createWebExportFilter(false))
 

--- a/test/commands/lib/deploy-actions.test.js
+++ b/test/commands/lib/deploy-actions.test.js
@@ -44,6 +44,7 @@ test('exports', () => {
 
 test('deploy-actions app hook available', async () => {
   utils.runScript.mockImplementation(script => {
+    console.log('script', script)
     if (script === 'deploy-actions') {
       return script
     }


### PR DESCRIPTION
Changing the way deployments go.
On file change, it should deploy only its respective action.
It should not redeploy twice the same action packages if redeployment is called unless files were changed.

**Clean up after the e2e/unit test gets implemented.** 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Create a filter array based on the current file changed. This will help the deploy function to decide which actions to deploy. 

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/468

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
