### PR TITLE
[ACNA-1249] Let developers bootstrap extensions XOR extensionless app from the selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ OPTIONS
 
   --[no-]web-assets          [default: true] Build web-assets if any
 
+  --web-optimize             [default: false] Enable optimization (minification) of js/css/html
+
 DESCRIPTION
   This will always force a rebuild unless --no-force-build is set.
 ```
@@ -488,6 +490,8 @@ OPTIONS
   --version                  Show version
 
   --[no-]web-assets          [default: true] Deploy web-assets if any
+
+  --web-optimize             [default: false] Enable optimization (minification) of web js/css/html
 
 DESCRIPTION
   This will always force a rebuild unless --no-force-build is set.

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -23,7 +23,6 @@ const { loadAndValidateConfigFile, importConfigJson } = require('../../lib/impor
 const { installPackages, atLeastOne } = require('../../lib/app-helper')
 
 const { ENTP_INT_CERTS_FOLDER, SERVICE_API_KEY_ENV, implPromptChoices } = require('../../lib/defaults')
-const cloneDeep = require('lodash.clonedeep')
 
 const DEFAULT_WORKSPACE = 'Stage'
 
@@ -143,16 +142,14 @@ class InitCommand extends BaseCommand {
       }
       return extList
     } else {
-      const choices = cloneDeep(implPromptChoices).filter(i => i.value.name !== 'application')
-
       // disable extensions that lack required services
       if (orgSupportedServices) {
         const supportedServiceCodes = new Set(orgSupportedServices.map(s => s.code))
         // filter choices
-        choices.forEach(c => {
+        implPromptChoices.forEach(c => {
           const missingServices = c.value.requiredServices.filter(s => !supportedServiceCodes.has(s))
           if (missingServices.length > 0) {
-            c.disabled = true
+            c.value = true
             c.name = `${c.name}: missing service(s) in Org: '${missingServices}'`
           }
         })
@@ -161,7 +158,7 @@ class InitCommand extends BaseCommand {
         type: 'checkbox',
         name: 'res',
         message: 'Which extension point(s) do you wish to implement ?',
-        choices,
+        choices: implPromptChoices,
         validate: atLeastOne
       }])
       return answers.res

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -245,14 +245,17 @@ class InitCommand extends BaseCommand {
 
   async runCodeGenerators (flags, extensionPoints, projectName) {
     let env = yeoman.createEnv()
-    // first run app generator that will generate the root skeleton
-    const appGen = env.instantiate(generators['base-app'], {
-      options: {
-        'skip-prompt': flags.yes,
-        'project-name': projectName
-      }
-    })
-    await env.runGenerator(appGen)
+    const initialGenerators = ['base-app', 'add-ci']
+    // first run app generator that will generate the root skeleton + ci
+    for (const generatorKey of initialGenerators) {
+      const appGen = env.instantiate(generators[generatorKey], {
+        options: {
+          'skip-prompt': flags.yes,
+          'project-name': projectName
+        }
+      })
+      await env.runGenerator(appGen)
+    }
 
     // Creating new Yeoman env here to workaround an issue where yeoman reuses the conflicter from previous environment.
     // https://github.com/yeoman/environment/issues/324

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -78,7 +78,7 @@ const inquirer = require('inquirer')
 const mockExtensionPrompt = jest.fn()
 inquirer.createPromptModule = jest.fn().mockReturnValue(mockExtensionPrompt)
 const { implPromptChoices } = require('../../../src/lib/defaults')
-const extChoices = implPromptChoices.filter(c => c.value.name !== 'application')
+const extChoices = implPromptChoices
 const excshellSelection = [implPromptChoices.find(c => c.value.name === 'dx/excshell/1').value]
 const assetComputeSelection = [implPromptChoices.find(c => c.value.name === 'dx/asset-compute/worker/1').value]
 
@@ -530,10 +530,12 @@ describe('run', () => {
         choices: [
         // exc shell
           extChoices[0],
+          extChoices[1],
           // disabled nui
           expect.objectContaining({
             disabled: true,
-            name: expect.stringContaining('missing service(s) in Org: \'AssetComputeSDK\'')
+            name: expect.stringContaining('missing service(s) in Org: \'AssetComputeSDK\''),
+            value: expect.any(Object)
           })
         ]
       })])

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -65,6 +65,7 @@ function resetMockConsoleCLI () {
 jest.mock('@adobe/generator-aio-app', () => ({
   application: 'fake-gen-application',
   'base-app': 'fake-gen-base-app',
+  'add-ci': 'fake-gen-add-ci',
   extensions: {
     'dx/excshell/1': 'fake-gen-excshell',
     'dx/asset-compute/worker/1': 'fake-gen-nui'
@@ -187,9 +188,13 @@ describe('run', () => {
   test('--no-login, select excshell', async () => {
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['--no-login'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -205,9 +210,13 @@ describe('run', () => {
   test('--no-login, select excshell, arg: /otherdir', async () => {
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['--no-login', '/otherdir'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'otherdir' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'otherdir' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -226,9 +235,13 @@ describe('run', () => {
   test('--no-login, select both', async () => {
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection.concat(assetComputeSelection) })
     await TheCommand.run(['--no-login'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(4)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -247,9 +260,13 @@ describe('run', () => {
 
   test('--no-login --no-extensions', async () => {
     await TheCommand.run(['--no-login', '--no-extensions'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -265,9 +282,13 @@ describe('run', () => {
   test('--no-login --yes --skip-install, select excshell', async () => {
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['--no-login', '--yes', '--skip-install'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -283,9 +304,13 @@ describe('run', () => {
   test('--no-login --yes --skip-install, --extension dx/asset-compute/worker/1', async () => {
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['--no-login', '--yes', '--skip-install', '--extension', 'dx/asset-compute/worker/1'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -333,9 +358,13 @@ describe('run', () => {
     mockImport.loadAndValidateConfigFile.mockReturnValue({ values: fakeConfig })
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['--import', 'fakeconfig.json'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -357,9 +386,13 @@ describe('run', () => {
     mockImport.loadAndValidateConfigFile.mockReturnValue({ values: fakeConfigNoCredentials })
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['--import', 'fakeconfig.json'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -395,9 +428,13 @@ describe('run', () => {
 
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run([])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -429,9 +466,13 @@ describe('run', () => {
 
     mockExtensionPrompt.mockReturnValue({ res: assetComputeSelection })
     await TheCommand.run([])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -469,9 +510,13 @@ describe('run', () => {
 
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run([])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -515,9 +560,13 @@ describe('run', () => {
     mockConsoleCLIInstance.promptForCreateProjectDetails.mockResolvedValue('fakedetails')
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run([])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -551,9 +600,13 @@ describe('run', () => {
     mockExtensionPrompt.mockReturnValue({})
 
     await TheCommand.run(['--extension', 'dx/excshell/1'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
@@ -585,9 +638,13 @@ describe('run', () => {
 
     mockExtensionPrompt.mockReturnValue({ res: excshellSelection })
     await TheCommand.run(['-w', 'dev'])
-    expect(mockGenInstantiate).toHaveBeenCalledTimes(2)
+    expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
+    )
+    expect(mockGenInstantiate).toHaveBeenCalledWith(
+      'fake-gen-add-ci',
       { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
User is provided with an way to initiate a blank application app via `aio app init`

<!--- Describe your changes in detail -->
Enabled the Standalone Application option on the Choose Extensions step.

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/453

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
