### PR TITLE
[ACNA-1357] Optimize deploy to skip build & deploy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@parcel/reporter-cli": "2.0.0-beta.3.1",
     "ajv": "^6.12.2",
     "chalk": "^4.0.0",
-    "chokidar": "^3.4.2",
+    "chokidar": "^3.5.2",
     "cli-ux": "^5.4.5",
     "debug": "^4.1.1",
     "dedent-js": "^1.0.1",

--- a/src/lib/actions-watcher.js
+++ b/src/lib/actions-watcher.js
@@ -41,7 +41,6 @@ module.exports = async (watcherOptions) => {
   log(`watching action files at ${config.actions.src}...`)
   const watcher = chokidar.watch(config.actions.src)
 
-  // todo: sometimes it fires twice, it might be a bug.
   watcher.on('change', createChangeHandler({ ...watcherOptions, watcher }))
 
   const cleanup = async () => {
@@ -82,6 +81,7 @@ function createChangeHandler (watcherOptions) {
   let undeployedFile = ''
 
   return async (filePath) => {
+    aioLogger.debug('Code change triggered...')
     if (deploymentInProgress) {
       aioLogger.debug(`${filePath} has changed. Deploy in progress. This change will be deployed after completion of current deployment.`)
       undeployedFile = filePath

--- a/test/commands/lib/actions-watcher.test.js
+++ b/test/commands/lib/actions-watcher.test.js
@@ -14,6 +14,7 @@ const chokidar = require('chokidar')
 const mockLogger = require('@adobe/aio-lib-core-logging')
 const buildActions = require('../../../src/lib/build-actions')
 const deployActions = require('../../../src/lib/deploy-actions')
+const buildAndDeploy = require('../../../src/lib/deploy-actions')
 const util = require('util')
 const dataMocks = require('../../data-mocks/config-loader')
 const sleep = util.promisify(setTimeout)
@@ -38,6 +39,7 @@ beforeEach(() => {
 
   buildActions.mockReset()
   deployActions.mockReset()
+  buildAndDeploy.mockReset()
 })
 
 test('exports', () => {
@@ -153,7 +155,7 @@ test('onChange handler calls buildActions with filterActions', async () => {
   )
 })
 
-test('onChange handler calls buildActions without filterActions when actions are undefined', async () => {
+test('on non-action file changed, skip build&deploy', async () => {
   const { application } = createAppConfig()
   const cloneApplication = cloneDeep(application)
   Object.entries(cloneApplication.manifest.full.packages).forEach(([, pkg]) => {
@@ -176,10 +178,10 @@ test('onChange handler calls buildActions without filterActions when actions are
   await actionsWatcher({ config: cloneApplication, log })
   expect(typeof onChangeHandler).toEqual('function')
 
-  deployActions.mockImplementation(async () => await sleep(2000))
-  onChangeHandler('/myactions/action.js')
+  buildAndDeploy.mockImplementation(async () => await sleep(2000))
+  onChangeHandler('/myactions/utils.js')
 
   await jest.runAllTimers()
 
-  expect(buildActions).toHaveBeenCalledWith(cloneApplication, [])
+  expect(buildAndDeploy).not.toHaveBeenCalledWith()
 })

--- a/test/commands/lib/actions-watcher.test.js
+++ b/test/commands/lib/actions-watcher.test.js
@@ -183,5 +183,5 @@ test('on non-action file changed, skip build&deploy', async () => {
 
   await jest.runAllTimers()
 
-  expect(buildAndDeploy).not.toHaveBeenCalledWith()
+  expect(buildAndDeploy).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing non-action files should not trigger `buildAndDeploy` process but instead, it should notify the user that those changes require an app restart in order to be deployed.

<!--- Describe your changes in detail -->
Skip deploying when the changed file path is not a valid action path. 
Updated `chokidar` to latest, changelog https://github.com/paulmillr/chokidar/compare/3.4.2...3.5.2

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/474
https://github.com/adobe/aio-lib-runtime/pull/75#issuecomment-945409660

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
