### PR TITLE
Fixed: log-forwarding secret settings are not saved

### DIFF
--- a/src/commands/app/config/get/log-forwarding.js
+++ b/src/commands/app/config/get/log-forwarding.js
@@ -21,8 +21,12 @@ class LogForwardingCommand extends BaseCommand {
 
     if (!localConfig.isEqual(serverConfig)) {
       this.log('Local and server log forwarding configuration is different')
-      this.log("Run either 'aio app:deploy' to update the server, " +
-        "or 'aio app:config:set:log-forwarding' to set new local and server configuration")
+      let message = 'Run'
+      if (localConfig.isDefined()) {
+        message += " either 'aio app:deploy' to update the server, or"
+      }
+      message += " 'aio app:config:set:log-forwarding' to set new local and server configuration"
+      this.log(message)
       this.log('Local configuration:')
       this.printConfig(localConfig)
       this.log('\nServer configuration:')

--- a/src/commands/app/config/set/log-forwarding.js
+++ b/src/commands/app/config/set/log-forwarding.js
@@ -24,7 +24,8 @@ class LogForwardingCommand extends BaseCommand {
     const res = await lf.updateServerConfig(lfConfig)
     this.log(`Log forwarding is set to '${destination}'`)
 
-    await lf.updateLocalConfig(lf.getConfigFromJson(res))
+    const fullSanitizedConfig = lfConfig.getMergedConfig(lf.getConfigFromJson(res))
+    await lf.updateLocalConfig(fullSanitizedConfig)
     this.log('Log forwarding settings are saved to the local configuration')
   }
 

--- a/src/lib/log-forwarding.js
+++ b/src/lib/log-forwarding.js
@@ -169,6 +169,14 @@ class LogForwardingConfig {
     return this.settings
   }
 
+  getMergedConfig (config) {
+    const newSettings = {}
+    Object.keys(this.settings).forEach(k => {
+      newSettings[k] = config.settings[k] !== undefined ? config.settings[k] : this.settings[k]
+    })
+    return new LogForwardingConfig(this.destination, newSettings)
+  }
+
   isDefined () {
     return this.destination !== undefined
   }

--- a/test/commands/app/config/get/log-forwarding.test.js
+++ b/test/commands/app/config/get/log-forwarding.test.js
@@ -134,7 +134,7 @@ test('get log forwarding settings (no local config)', async () => {
     return command.run()
       .then(() => {
         expect(stdout.output).toEqual('Local and server log forwarding configuration is different\n' +
-          "Run either 'aio app:deploy' to update the server, or 'aio app:config:set:log-forwarding' to set new local and server configuration\n" +
+          "Run 'aio app:config:set:log-forwarding' to set new local and server configuration\n" +
           'Local configuration:\n' +
           'Not defined\n\n' +
           'Server configuration:\n' +

--- a/test/commands/app/config/set/log-forwarding.test.js
+++ b/test/commands/app/config/set/log-forwarding.test.js
@@ -53,13 +53,19 @@ test('set log forwarding destination', async () => {
     const destination = 'destination'
     const input = {
       field_one: 'val_one',
-      field_two: 'val_two'
+      field_two: 'val_two',
+      secret: 'val_secret'
     }
     command.prompt.mockResolvedValueOnce({ type: destination })
     command.prompt.mockResolvedValueOnce(input)
     const serverSanitizedSettings = {
       field_one: 'val_one',
       field_two: 'val_two sanitized'
+    }
+    const fullSanitizedSettings = {
+      field_one: 'val_one',
+      field_two: 'val_two sanitized',
+      secret: 'val_secret'
     }
     const setCall = jest.fn().mockResolvedValue({
       destination: serverSanitizedSettings
@@ -80,7 +86,7 @@ test('set log forwarding destination', async () => {
         expect(setCall).toBeCalledTimes(1)
         expect(setCall).toHaveBeenCalledWith(new LogForwarding.LogForwardingConfig(destination, input))
         expect(localSetCall).toBeCalledTimes(1)
-        expect(localSetCall).toHaveBeenCalledWith(new LogForwarding.LogForwardingConfig(destination, serverSanitizedSettings))
+        expect(localSetCall).toHaveBeenCalledWith(new LogForwarding.LogForwardingConfig(destination, fullSanitizedSettings))
         resolve()
       })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Fix for: Log Forwarding secrets are not saved in the project's `.env` file.
- Improved log forwarding message in case local config is absent

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manual and auto tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
