### PR TITLE
log-forwarding config: downplay spinner messaging

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -58,7 +58,12 @@ class Deploy extends BuildCommand {
     try {
       const aioConfig = this.getFullConfig().aio
       // 1. update log forwarding configuration
-      if (flags['log-forwarding-update'] && flags.actions) {
+      // note: it is possible that .aio file does not exist, which means there is no local lg config
+      if (aioConfig &&
+          aioConfig.project &&
+          aioConfig.project.workspace &&
+          flags['log-forwarding-update'] &&
+          flags.actions) {
         spinner.start('Updating log forwarding configuration')
         try {
           const lf = await LogForwarding.init(aioConfig)
@@ -68,10 +73,12 @@ class Deploy extends BuildCommand {
               await lf.updateServerConfig(lfConfig)
               spinner.succeed(chalk.green(`Log forwarding is set to '${lfConfig.getDestination()}'`))
             } else {
-              spinner.fail(chalk.green('Log forwarding is not updated: no configuration is provided'))
+              if (flags.verbose) {
+                spinner.info(chalk.dim('Log forwarding is not updated: no configuration is provided'))
+              }
             }
           } else {
-            spinner.fail(chalk.green('Log forwarding is not updated: configuration not changed since last update'))
+            spinner.info(chalk.dim('Log forwarding is not updated: configuration not changed since last update'))
           }
         } catch (error) {
           spinner.fail(chalk.red('Log forwarding is not updated.'))

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -902,6 +902,15 @@ describe('run', () => {
     expect(mockLogForwarding.updateServerConfig).toBeCalledTimes(0)
   })
 
+  test('log forwarding is not updated on server when local config is absent --verbose', async () => {
+    command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
+    const config = new LogForwarding.LogForwardingConfig()
+    mockLogForwarding.getLocalConfigWithSecrets.mockReturnValue(config)
+    command.argv = ['--verbose']
+    await command.run()
+    expect(mockLogForwarding.updateServerConfig).toBeCalledTimes(0)
+  })
+
   test('log forwarding is not updated on server when local config not changed', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
     mockLogForwarding.isLocalConfigChanged.mockReturnValue(false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- spinner.info instead of spinner.error
- chalk.dim instead of chalk.green
- only display **Log forwarding is not updated: no configuration is provided** if `--verbose`
- adds sanity check for missing .aio file or properties, no deeper processing is done


## Screenshots (if appropriate):
- `aio app deploy` (not verbose)
![Screen Shot 2022-01-26 at 12 09 30 PM](https://user-images.githubusercontent.com/46134/151260076-a31db2e5-352e-4eed-b8fd-25c6b582d41b.png)

- `aio app deploy --verbose`
![Screen Shot 2022-01-26 at 11 49 43 AM](https://user-images.githubusercontent.com/46134/151260198-d00e5626-d6bb-415e-be02-9d6c4dd3db5b.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
