### PR TITLE
Fix links to source code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/index.ts)_
+_See code: [src/commands/app/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/index.js)_
 
 ## `aio app:add`
 
@@ -90,7 +90,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/add/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/index.ts)_
+_See code: [src/commands/app/add/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/index.js)_
 
 ## `aio app:add:action`
 
@@ -112,7 +112,7 @@ ALIASES
   $ aio app:add:actions
 ```
 
-_See code: [src/commands/app/add/action.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/action.ts)_
+_See code: [src/commands/app/add/action.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/action.js)_
 
 ## `aio app:add:ci`
 
@@ -127,7 +127,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/add/ci.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/ci.ts)_
+_See code: [src/commands/app/add/ci.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/ci.js)_
 
 ## `aio app:add:event`
 
@@ -149,7 +149,7 @@ ALIASES
   $ aio app:add:events
 ```
 
-_See code: [src/commands/app/add/event.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/event.ts)_
+_See code: [src/commands/app/add/event.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/event.js)_
 
 ## `aio app:add:extension`
 
@@ -172,7 +172,7 @@ ALIASES
   $ aio app:add:extensions
 ```
 
-_See code: [src/commands/app/add/extension.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/extension.ts)_
+_See code: [src/commands/app/add/extension.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/extension.js)_
 
 ## `aio app:add:service`
 
@@ -190,7 +190,7 @@ ALIASES
   $ aio app:add:services
 ```
 
-_See code: [src/commands/app/add/service.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/service.ts)_
+_See code: [src/commands/app/add/service.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/service.js)_
 
 ## `aio app:add:web-assets`
 
@@ -209,7 +209,7 @@ OPTIONS
   --version                  Show version
 ```
 
-_See code: [src/commands/app/add/web-assets.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/web-assets.ts)_
+_See code: [src/commands/app/add/web-assets.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/add/web-assets.js)_
 
 ## `aio app:build`
 
@@ -249,7 +249,7 @@ DESCRIPTION
   This will always force a rebuild unless --no-force-build is set.
 ```
 
-_See code: [src/commands/app/build.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/build.ts)_
+_See code: [src/commands/app/build.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/build.js)_
 
 ## `aio app:config`
 
@@ -268,7 +268,7 @@ ALIASES
   $ aio app:config
 ```
 
-_See code: [src/commands/app/config/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/index.ts)_
+_See code: [src/commands/app/config/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/index.js)_
 
 ## `aio app:config:get`
 
@@ -286,7 +286,7 @@ ALIASES
   $ aio app:config:get
 ```
 
-_See code: [src/commands/app/config/get/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/get/index.ts)_
+_See code: [src/commands/app/config/get/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/get/index.js)_
 
 ## `aio app:config:get:log-forwarding`
 
@@ -305,7 +305,7 @@ ALIASES
   $ aio app:config:get:lf
 ```
 
-_See code: [src/commands/app/config/get/log-forwarding.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/get/log-forwarding.ts)_
+_See code: [src/commands/app/config/get/log-forwarding.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/get/log-forwarding.js)_
 
 ## `aio app:config:get:log-forwarding:errors`
 
@@ -324,7 +324,7 @@ ALIASES
   $ aio app:config:get:lf:errors
 ```
 
-_See code: [src/commands/app/config/get/log-forwarding/errors.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/get/log-forwarding/errors.ts)_
+_See code: [src/commands/app/config/get/log-forwarding/errors.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/get/log-forwarding/errors.js)_
 
 ## `aio app:config:set`
 
@@ -342,7 +342,7 @@ ALIASES
   $ aio app:config:set
 ```
 
-_See code: [src/commands/app/config/set/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/set/index.ts)_
+_See code: [src/commands/app/config/set/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/set/index.js)_
 
 ## `aio app:config:set:log-forwarding`
 
@@ -361,7 +361,7 @@ ALIASES
   $ aio app:config:set:lf
 ```
 
-_See code: [src/commands/app/config/set/log-forwarding.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/set/log-forwarding.ts)_
+_See code: [src/commands/app/config/set/log-forwarding.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/config/set/log-forwarding.js)_
 
 ## `aio app:create [PATH]`
 
@@ -380,7 +380,7 @@ OPTIONS
   --version            Show version
 ```
 
-_See code: [src/commands/app/create.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/create.ts)_
+_See code: [src/commands/app/create.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/create.js)_
 
 ## `aio app:delete`
 
@@ -395,7 +395,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/delete/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/index.ts)_
+_See code: [src/commands/app/delete/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/index.js)_
 
 ## `aio app:delete:action [ACTION-NAME]`
 
@@ -417,7 +417,7 @@ ALIASES
   $ aio app:delete:actions
 ```
 
-_See code: [src/commands/app/delete/action.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/action.ts)_
+_See code: [src/commands/app/delete/action.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/action.js)_
 
 ## `aio app:delete:ci`
 
@@ -433,7 +433,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/delete/ci.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/ci.ts)_
+_See code: [src/commands/app/delete/ci.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/ci.js)_
 
 ## `aio app:delete:event [EVENT-ACTION-NAME]`
 
@@ -455,7 +455,7 @@ ALIASES
   $ aio app:delete:events
 ```
 
-_See code: [src/commands/app/delete/event.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/event.ts)_
+_See code: [src/commands/app/delete/event.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/event.js)_
 
 ## `aio app:delete:extension`
 
@@ -477,7 +477,7 @@ ALIASES
   $ aio app:delete:extensions
 ```
 
-_See code: [src/commands/app/delete/extension.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/extension.ts)_
+_See code: [src/commands/app/delete/extension.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/extension.js)_
 
 ## `aio app:delete:service`
 
@@ -495,7 +495,7 @@ ALIASES
   $ aio app:delete:services
 ```
 
-_See code: [src/commands/app/delete/service.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/service.ts)_
+_See code: [src/commands/app/delete/service.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/service.js)_
 
 ## `aio app:delete:web-assets`
 
@@ -511,7 +511,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/delete/web-assets.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/web-assets.ts)_
+_See code: [src/commands/app/delete/web-assets.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/delete/web-assets.js)_
 
 ## `aio app:deploy`
 
@@ -566,7 +566,7 @@ DESCRIPTION
   This will always force a rebuild unless --no-force-build is set.
 ```
 
-_See code: [src/commands/app/deploy.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/deploy.ts)_
+_See code: [src/commands/app/deploy.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/deploy.js)_
 
 ## `aio app:get-url [ACTION]`
 
@@ -586,7 +586,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/get-url.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/get-url.ts)_
+_See code: [src/commands/app/get-url.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/get-url.js)_
 
 ## `aio app:info`
 
@@ -605,7 +605,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/info.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/info.ts)_
+_See code: [src/commands/app/info.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/info.js)_
 
 ## `aio app:init [PATH]`
 
@@ -640,7 +640,7 @@ OPTIONS
   --version                  Show version
 ```
 
-_See code: [src/commands/app/init.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/init.ts)_
+_See code: [src/commands/app/init.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/init.js)_
 
 ## `aio app:list`
 
@@ -655,7 +655,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/app/list/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/list/index.ts)_
+_See code: [src/commands/app/list/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/list/index.js)_
 
 ## `aio app:list:extension`
 
@@ -676,7 +676,7 @@ ALIASES
   $ aio app:list:extensions
 ```
 
-_See code: [src/commands/app/list/extension.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/list/extension.ts)_
+_See code: [src/commands/app/list/extension.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/list/extension.js)_
 
 ## `aio app:list:extension-points`
 
@@ -697,7 +697,7 @@ ALIASES
   $ aio app:list:extension-points
 ```
 
-_See code: [src/commands/app/list/extension-points.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/list/extension-points.ts)_
+_See code: [src/commands/app/list/extension-points.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/list/extension-points.js)_
 
 ## `aio app:logs`
 
@@ -718,7 +718,7 @@ OPTIONS
   --version            Show version
 ```
 
-_See code: [src/commands/app/logs.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/logs.ts)_
+_See code: [src/commands/app/logs.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/logs.js)_
 
 ## `aio app:run`
 
@@ -739,7 +739,7 @@ OPTIONS
   --version                  Show version
 ```
 
-_See code: [src/commands/app/run.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/run.ts)_
+_See code: [src/commands/app/run.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/run.js)_
 
 ## `aio app:test`
 
@@ -764,7 +764,7 @@ DESCRIPTION
   If the extension has a hook called 'test' in its 'ext.config.yaml', the script specified will be run instead.
 ```
 
-_See code: [src/commands/app/test.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/test.ts)_
+_See code: [src/commands/app/test.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/test.js)_
 
 ## `aio app:undeploy`
 
@@ -787,7 +787,7 @@ OPTIONS
   --[no-]web-assets          [default: true] Undeploy web-assets if any
 ```
 
-_See code: [src/commands/app/undeploy.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/undeploy.ts)_
+_See code: [src/commands/app/undeploy.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/undeploy.js)_
 
 ## `aio app:use [CONFIG_FILE_PATH]`
 
@@ -840,5 +840,5 @@ DESCRIPTION
   page in https://console.adobe.io
 ```
 
-_See code: [src/commands/app/use.ts](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/use.ts)_
+_See code: [src/commands/app/use.js](https://github.com/adobe/aio-cli-plugin-app/blob/8.6.1/src/commands/app/use.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "jest": "^26.6.3",
     "jest-plugin-fs": "^2.9.0",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^4.5.2"
+    "stdout-stderr": "^0.1.9"
   },
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Modified README to change file extensions in links to source code from `.ts` to `.js`.

## Related Issue

## Motivation and Context

This change is required so that links to source files will work. 

## How Has This Been Tested?

Manually tested via personal fork of repository.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
