### PR TITLE
remove adding runtime apihost to env config

### DIFF
--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -16,7 +16,6 @@ module.exports = {
   defaultAppHostname: 'adobeio-static.net',
   stageAppHostname: 'dev.runtime.adobe.io',
   defaultTvmUrl: 'https://firefly-tvm.adobe.io',
-  defaultOwApihost: 'https://adobeioruntime.net',
   defaultHTMLCacheDuration: '60',
   defaultJSCacheDuration: '604800',
   defaultCSSCacheDuration: '604800',

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:import', { provider: 'debug' })
 const config = require('@adobe/aio-lib-core-config')
-const defaults = require('./defaults')
 const path = require('path')
 const fs = require('fs-extra')
 const inquirer = require('inquirer')
@@ -489,8 +488,6 @@ function transformRuntime (runtime) {
   if (newRuntime.name) {
     newRuntime.namespace = newRuntime.name
     delete newRuntime.name
-    // apihost is not sent in console config
-    newRuntime.apihost = defaults.defaultOwApihost
   }
 
   return newRuntime

--- a/test/__fixtures__/existing.merged.env
+++ b/test/__fixtures__/existing.merged.env
@@ -4,7 +4,6 @@ AIO_foo_bar=baz
 AIO_boo=faz
 AIO_runtime_auth=Auth
 AIO_runtime_namespace=Name
-AIO_runtime_apihost=https://adobeioruntime.net
 AIO_ims_contexts_Projéct__A_client__id=XYXYXYXYXYXYXYXYX
 AIO_ims_contexts_Projéct__A_client__secret=XYXYXYXYZZZZZZ
 AIO_ims_contexts_Projéct__A_redirect__uri=["https://test123"]

--- a/test/__fixtures__/valid.config.env
+++ b/test/__fixtures__/valid.config.env
@@ -1,6 +1,5 @@
 AIO_runtime_auth=Auth
 AIO_runtime_namespace=Name
-AIO_runtime_apihost=https://adobeioruntime.net
 AIO_ims_contexts_Projéct__A_client__id=XYXYXYXYXYXYXYXYX
 AIO_ims_contexts_Projéct__A_client__secret=XYXYXYXYZZZZZZ
 AIO_ims_contexts_Projéct__A_redirect__uri=["https://test123"]


### PR DESCRIPTION
## Description

Remove adding runtime apihost during environment config generation.

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
