### PR TITLE
fix: force build on every aio app run (for switching from remote and local contexts)

### DIFF
--- a/src/lib/build-actions.js
+++ b/src/lib/build-actions.js
@@ -18,12 +18,13 @@ const { buildActions } = require('@adobe/aio-lib-runtime')
  *
  * @param {object} config see src/lib/config-loader.js
  * @param {Array<string>} filterActions add filters to deploy only specified OpenWhisk actions
+ * @param {boolean} [forceBuild=false] force a build (skip file changed hash check)
  */
-module.exports = async (config, filterActions) => {
+module.exports = async (config, filterActions, forceBuild = false) => {
   utils.runScript(config.hooks['pre-app-build'])
   const script = await utils.runScript(config.hooks['build-actions'])
   if (!script) {
-    await buildActions(config, filterActions)
+    await buildActions(config, filterActions, forceBuild)
   }
   utils.runScript(config.hooks['post-app-build'])
 }

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -80,7 +80,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}) {
 
       // build and deploy actions
       log('building actions..')
-      await buildActions(devConfig)
+      await buildActions(devConfig, null, true /* force build */)
 
       const { cleanup: watcherCleanup } = await actionsWatcher({ config: devConfig, isLocal, log })
       cleanup.add(() => watcherCleanup(), 'stopping action watcher...')

--- a/test/commands/app/run.test.js
+++ b/test/commands/app/run.test.js
@@ -289,7 +289,7 @@ describe('run', () => {
     }), expect.any(Function))
   })
 
-  test('app:run with -verbose', async () => {
+  test('app:run with --verbose', async () => {
     mockFSExists([PRIVATE_KEY_PATH, PUB_CERT_PATH])
     command.argv = ['--verbose']
     const appConfig = createAppConfig(command.appConfig)

--- a/test/commands/lib/build-actions.test.js
+++ b/test/commands/lib/build-actions.test.js
@@ -55,3 +55,17 @@ test('no build-actions app hook available (use inbuilt)', async () => {
   expect(utils.runScript).toHaveBeenNthCalledWith(2, 'build-actions')
   expect(utils.runScript).toHaveBeenNthCalledWith(3, 'post-app-build')
 })
+
+test('forceBuild false (default)', async () => {
+  await buildActions(extensionConfig)
+
+  expect(rtBuildActions).toHaveBeenCalled()
+  expect(rtBuildActions).toHaveBeenCalledWith(extensionConfig, undefined, false)
+})
+
+test('forceBuild true', async () => {
+  await buildActions(extensionConfig, null, true)
+
+  expect(rtBuildActions).toHaveBeenCalled()
+  expect(rtBuildActions).toHaveBeenCalledWith(extensionConfig, null, true)
+})

--- a/test/commands/lib/run-dev.test.js
+++ b/test/commands/lib/run-dev.test.js
@@ -408,3 +408,12 @@ test('devRemote true, build-static hook set, serve-static hook not set)', async 
   expect(logPoller.run).not.toHaveBeenCalled()
   expect(actionsWatcher).toHaveBeenCalled()
 })
+
+test('runDev always force builds', async () => {
+  const config = cloneDeep(createAppConfig().application)
+
+  await runDev(config, DATA_DIR, { devRemote: true })
+
+  expect(buildActions).toHaveBeenCalled()
+  expect(buildActions).toHaveBeenCalledWith(expect.any(Object) /* config */, null /* filterActions */, true /* forceBuild */)
+})


### PR DESCRIPTION
## Description

Fixes #542 
(see issue for use case)

In a nutshell, we will always force deploy actions on every `aio app run` (doesn't matter if there are no code changes).

## How Has This Been Tested?

npm test
manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
