### PR TITLE
fix: ACNA-1687 | fix option skipInstall for generators

### DIFF
--- a/src/commands/app/add/action.js
+++ b/src/commands/app/add/action.js
@@ -46,6 +46,7 @@ class AddActionCommand extends AddCommand {
     const supportedOrgServices = aioConfigLoader.get('project.org.details.services') || []
 
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const addActionGen = env.instantiate(generators['add-action'], {
       options: {
@@ -55,9 +56,7 @@ class AddActionCommand extends AddCommand {
         'adobe-services': servicesToGeneratorInput(workspaceServices),
         'supported-adobe-services': servicesToGeneratorInput(supportedOrgServices),
         'full-key-to-manifest': configData.key
-        // force: true,
-        // by default yeoman runs the install, we control installation from the app plugin
-        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
+        // force: true
       }
     })
     await env.runGenerator(addActionGen)

--- a/src/commands/app/add/action.js
+++ b/src/commands/app/add/action.js
@@ -46,6 +46,7 @@ class AddActionCommand extends AddCommand {
     const supportedOrgServices = aioConfigLoader.get('project.org.details.services') || []
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const addActionGen = env.instantiate(generators['add-action'], {
       options: {
         'skip-prompt': flags.yes,
@@ -53,10 +54,10 @@ class AddActionCommand extends AddCommand {
         'config-path': configData.file,
         'adobe-services': servicesToGeneratorInput(workspaceServices),
         'supported-adobe-services': servicesToGeneratorInput(supportedOrgServices),
-        'full-key-to-manifest': configData.key,
+        'full-key-to-manifest': configData.key
         // force: true,
         // by default yeoman runs the install, we control installation from the app plugin
-        'skip-install': true
+        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(addActionGen)

--- a/src/commands/app/add/ci.js
+++ b/src/commands/app/add/ci.js
@@ -21,11 +21,12 @@ class AddCICommand extends BaseCommand {
     aioLogger.debug(`adding component ${args.component} to the project, using flags: ${flags}`)
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const gen = env.instantiate(
       generators['add-ci'], {
         options: {
           // by default yeoman runs the installation, we control installation from the app plugin
-          'skip-install': true
+          // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
         }
       })
     await env.runGenerator(gen)

--- a/src/commands/app/add/ci.js
+++ b/src/commands/app/add/ci.js
@@ -21,13 +21,11 @@ class AddCICommand extends BaseCommand {
     aioLogger.debug(`adding component ${args.component} to the project, using flags: ${flags}`)
 
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const gen = env.instantiate(
       generators['add-ci'], {
-        options: {
-          // by default yeoman runs the installation, we control installation from the app plugin
-          // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
-        }
+        options: { }
       })
     await env.runGenerator(gen)
   }

--- a/src/commands/app/add/event.js
+++ b/src/commands/app/add/event.js
@@ -35,6 +35,7 @@ class AddEventCommand extends AddCommand {
     const configData = this.getRuntimeManifestConfigFile(configName)
 
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const eventsGen = env.instantiate(generators['add-events'], {
       options: {
@@ -44,8 +45,6 @@ class AddEventCommand extends AddCommand {
         'full-key-to-manifest': configData.key,
         // force overwrites, no useless prompts, this is a feature exposed by yeoman itself
         force: true
-        // by default yeoman runs the install, we control installation from the app plugin
-        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(eventsGen)

--- a/src/commands/app/add/event.js
+++ b/src/commands/app/add/event.js
@@ -35,6 +35,7 @@ class AddEventCommand extends AddCommand {
     const configData = this.getRuntimeManifestConfigFile(configName)
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const eventsGen = env.instantiate(generators['add-events'], {
       options: {
         'skip-prompt': flags.yes,
@@ -42,9 +43,9 @@ class AddEventCommand extends AddCommand {
         'config-path': configData.file,
         'full-key-to-manifest': configData.key,
         // force overwrites, no useless prompts, this is a feature exposed by yeoman itself
-        force: true,
+        force: true
         // by default yeoman runs the install, we control installation from the app plugin
-        'skip-install': true
+        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(eventsGen)

--- a/src/commands/app/add/extension.js
+++ b/src/commands/app/add/extension.js
@@ -91,6 +91,7 @@ class AddExtensionCommand extends AddCommand {
 
   async runCodeGenerators (flags, implementations) {
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     for (let i = 0; i < implementations.length; ++i) {
       const implementation = implementations[i]
@@ -100,8 +101,6 @@ class AddExtensionCommand extends AddCommand {
             'skip-prompt': flags.yes,
             // no yeoman overwrite prompts
             force: true
-            // by default yeoman runs the install, we control installation from the app plugin
-            // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
           }
         })
       this.log(chalk.blue(chalk.bold(`Running generator for ${implementation.name}`)))

--- a/src/commands/app/add/extension.js
+++ b/src/commands/app/add/extension.js
@@ -91,6 +91,7 @@ class AddExtensionCommand extends AddCommand {
 
   async runCodeGenerators (flags, implementations) {
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     for (let i = 0; i < implementations.length; ++i) {
       const implementation = implementations[i]
       const gen = env.instantiate(implementation.generator,
@@ -98,9 +99,9 @@ class AddExtensionCommand extends AddCommand {
           options: {
             'skip-prompt': flags.yes,
             // no yeoman overwrite prompts
-            force: true,
+            force: true
             // by default yeoman runs the install, we control installation from the app plugin
-            'skip-install': true
+            // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
           }
         })
       this.log(chalk.blue(chalk.bold(`Running generator for ${implementation.name}`)))

--- a/src/commands/app/add/web-assets.js
+++ b/src/commands/app/add/web-assets.js
@@ -39,6 +39,7 @@ class AddWebAssetsCommand extends AddCommand {
       []
 
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const gen = env.instantiate(generators['add-web-assets'], {
       options: {
@@ -46,9 +47,7 @@ class AddWebAssetsCommand extends AddCommand {
         'project-name': projectName,
         'web-src-folder': webSrcFolder,
         'adobe-services': servicesToGeneratorInput(workspaceServices)
-        // force: true,
-        // by default yeoman runs the install, we control installation from the app plugin
-        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
+        // force: true
       }
     })
     await env.runGenerator(gen)

--- a/src/commands/app/add/web-assets.js
+++ b/src/commands/app/add/web-assets.js
@@ -39,15 +39,16 @@ class AddWebAssetsCommand extends AddCommand {
       []
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const gen = env.instantiate(generators['add-web-assets'], {
       options: {
         'skip-prompt': flags.yes,
         'project-name': projectName,
         'web-src-folder': webSrcFolder,
-        'adobe-services': servicesToGeneratorInput(workspaceServices),
+        'adobe-services': servicesToGeneratorInput(workspaceServices)
         // force: true,
         // by default yeoman runs the install, we control installation from the app plugin
-        'skip-install': true
+        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(gen)

--- a/src/commands/app/delete/ci.js
+++ b/src/commands/app/delete/ci.js
@@ -22,11 +22,12 @@ class DeleteCICommand extends BaseCommand {
     aioLogger.debug(`deleting CI files from the project, using flags: ${JSON.stringify(flags)}`)
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const gen = env.instantiate(generators['delete-ci'], {
       options: {
-        'skip-prompt': flags.yes,
+        'skip-prompt': flags.yes
         // by default yeoman runs the install, we control installation from the app plugin
-        'skip-install': true
+        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(gen)

--- a/src/commands/app/delete/ci.js
+++ b/src/commands/app/delete/ci.js
@@ -22,12 +22,11 @@ class DeleteCICommand extends BaseCommand {
     aioLogger.debug(`deleting CI files from the project, using flags: ${JSON.stringify(flags)}`)
 
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const gen = env.instantiate(generators['delete-ci'], {
       options: {
         'skip-prompt': flags.yes
-        // by default yeoman runs the install, we control installation from the app plugin
-        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(gen)

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -271,15 +271,16 @@ class InitCommand extends AddCommand {
 
   async runCodeGenerators (flags, extensionPoints, projectName) {
     let env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const initialGenerators = ['base-app', 'add-ci']
     // first run app generator that will generate the root skeleton + ci
     for (const generatorKey of initialGenerators) {
       const appGen = env.instantiate(generators[generatorKey], {
         options: {
           'skip-prompt': flags.yes,
-          'project-name': projectName,
+          'project-name': projectName
           // by default yeoman runs the install, we control installation from the app plugin
-          'skip-install': true
+          // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
         }
       })
       await env.runGenerator(appGen)
@@ -289,6 +290,7 @@ class InitCommand extends AddCommand {
     // https://github.com/yeoman/environment/issues/324
 
     env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     // try to use appGen.composeWith
     for (let i = 0; i < extensionPoints.length; ++i) {
       const extGen = env.instantiate(
@@ -297,9 +299,9 @@ class InitCommand extends AddCommand {
           options: {
             'skip-prompt': flags.yes,
             // do not prompt for overwrites
-            force: true,
+            force: true
             // by default yeoman runs the install, we control installation from the app plugin
-            'skip-install': true
+            // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
           }
         })
       await env.runGenerator(extGen)

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -271,6 +271,7 @@ class InitCommand extends AddCommand {
 
   async runCodeGenerators (flags, extensionPoints, projectName) {
     let env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const initialGenerators = ['base-app', 'add-ci']
     // first run app generator that will generate the root skeleton + ci
@@ -279,8 +280,6 @@ class InitCommand extends AddCommand {
         options: {
           'skip-prompt': flags.yes,
           'project-name': projectName
-          // by default yeoman runs the install, we control installation from the app plugin
-          // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
         }
       })
       await env.runGenerator(appGen)
@@ -290,6 +289,7 @@ class InitCommand extends AddCommand {
     // https://github.com/yeoman/environment/issues/324
 
     env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     // try to use appGen.composeWith
     for (let i = 0; i < extensionPoints.length; ++i) {
@@ -300,8 +300,6 @@ class InitCommand extends AddCommand {
             'skip-prompt': flags.yes,
             // do not prompt for overwrites
             force: true
-            // by default yeoman runs the install, we control installation from the app plugin
-            // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
           }
         })
       await env.runGenerator(extGen)

--- a/src/lib/vscode.js
+++ b/src/lib/vscode.js
@@ -42,6 +42,7 @@ function update (config) {
     }
 
     const env = yeoman.createEnv()
+    // by default yeoman runs the install, we control installation from the app plugin
     env.options = { skipInstall: true }
     const gen = env.instantiate(generators['add-vscode-config'], {
       options: {
@@ -49,8 +50,6 @@ function update (config) {
         'env-file': config.envFile,
         'frontend-url': props.frontEndUrl,
         'skip-prompt': true
-        // by default yeoman runs the install, we control installation from the app plugin
-        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(gen)

--- a/src/lib/vscode.js
+++ b/src/lib/vscode.js
@@ -42,14 +42,15 @@ function update (config) {
     }
 
     const env = yeoman.createEnv()
+    env.options = { skipInstall: true }
     const gen = env.instantiate(generators['add-vscode-config'], {
       options: {
         'app-config': config,
         'env-file': config.envFile,
         'frontend-url': props.frontEndUrl,
-        'skip-prompt': true,
+        'skip-prompt': true
         // by default yeoman runs the install, we control installation from the app plugin
-        'skip-install': true
+        // Moving ['skip-install': true] to env.options due to yeoman environment issue https://github.com/yeoman/environment/issues/421
       }
     })
     await env.runGenerator(gen)

--- a/test/commands/app/add/action.test.js
+++ b/test/commands/app/add/action.test.js
@@ -100,8 +100,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': undefined,
         'supported-adobe-services': undefined,
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
     expect(mockRunGenerator).toHaveBeenCalledWith('actionGen')
@@ -120,8 +119,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': undefined,
         'supported-adobe-services': undefined,
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
     expect(helpers.installPackages).toHaveBeenCalledTimes(0)
@@ -139,8 +137,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': undefined,
         'supported-adobe-services': undefined,
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
   })
@@ -157,8 +154,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': undefined,
         'supported-adobe-services': undefined,
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
   })
@@ -174,8 +170,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': undefined,
         'supported-adobe-services': undefined,
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
   })
@@ -203,8 +198,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': 'CampaignSDK,AdobeAnalyticsSDK',
         'supported-adobe-services': 'CampaignSDK,AdobeAnalyticsSDK,AnotherOneSDK',
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
   })
@@ -232,8 +226,7 @@ describe('good flags', () => {
         'config-path': undefined,
         'adobe-services': 'CampaignSDK,AdobeAnalyticsSDK',
         'supported-adobe-services': 'CampaignSDK,AdobeAnalyticsSDK,AnotherOneSDK',
-        'full-key-to-manifest': 'undefined.runtimeManifest',
-        'skip-install': true
+        'full-key-to-manifest': 'undefined.runtimeManifest'
       }
     })
   })

--- a/test/commands/app/add/ci.test.js
+++ b/test/commands/app/add/ci.test.js
@@ -60,7 +60,7 @@ describe('no flags', () => {
     await TheCommand.run([])
 
     expect(yeoman.createEnv).toHaveBeenCalled()
-    expect(mockInstantiate).toHaveBeenCalledWith(generators['add-ci'], { options: { 'skip-install': true } })
+    expect(mockInstantiate).toHaveBeenCalledWith(generators['add-ci'], { options: { } })
     expect(mockRunGenerator).toHaveBeenCalled()
   })
 })

--- a/test/commands/app/add/event.test.js
+++ b/test/commands/app/add/event.test.js
@@ -98,8 +98,7 @@ describe('good flags', () => {
         'action-folder': 'myactions',
         'config-path': undefined,
         'full-key-to-manifest': 'undefined.runtimeManifest',
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
     expect(mockRunGenerator).toHaveBeenCalledWith('eventsGen')
@@ -126,8 +125,7 @@ describe('good flags', () => {
         'action-folder': 'myactions',
         'config-path': undefined,
         'full-key-to-manifest': 'undefined.runtimeManifest',
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
     expect(helpers.installPackages).toHaveBeenCalledTimes(0)

--- a/test/commands/app/add/extension.test.js
+++ b/test/commands/app/add/extension.test.js
@@ -101,8 +101,7 @@ describe('good flags', () => {
     expect(mockInstantiate).toHaveBeenCalledWith(generators.extensions['dx/excshell/1'], {
       options: {
         'skip-prompt': true,
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
     expect(mockRunGenerator).toHaveBeenCalledWith('extGen')
@@ -117,8 +116,7 @@ describe('good flags', () => {
     expect(mockInstantiate).toHaveBeenCalledWith(generators.extensions['dx/excshell/1'], {
       options: {
         'skip-prompt': true,
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
     expect(helpers.installPackages).toHaveBeenCalledTimes(0)
@@ -132,8 +130,7 @@ describe('good flags', () => {
     expect(mockInstantiate).toHaveBeenCalledWith(generators.extensions['dx/excshell/1'], {
       options: {
         'skip-prompt': false,
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
   })
@@ -145,8 +142,7 @@ describe('good flags', () => {
     expect(mockInstantiate).toHaveBeenCalledWith(generators.extensions['dx/excshell/1'], {
       options: {
         'skip-prompt': false,
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
   })
@@ -171,8 +167,7 @@ describe('good flags', () => {
     expect(mockInstantiate).toHaveBeenCalledWith(generators.extensions['dx/asset-compute/worker/1'], {
       options: {
         'skip-prompt': false,
-        force: true,
-        'skip-install': true
+        force: true
       }
     })
   })

--- a/test/commands/app/add/web-assets.test.js
+++ b/test/commands/app/add/web-assets.test.js
@@ -98,8 +98,7 @@ describe('good flags', () => {
         'skip-prompt': true,
         'project-name': 'legacy-app',
         'web-src-folder': path.resolve('/web-src'),
-        'adobe-services': undefined,
-        'skip-install': true
+        'adobe-services': undefined
       }
     })
     expect(mockRunGenerator).toHaveBeenCalledWith('gen')
@@ -116,8 +115,7 @@ describe('good flags', () => {
         'skip-prompt': true,
         'project-name': 'legacy-app',
         'web-src-folder': path.resolve('/web-src'),
-        'adobe-services': undefined,
-        'skip-install': true
+        'adobe-services': undefined
       }
     })
     expect(helpers.installPackages).toHaveBeenCalledTimes(0)
@@ -133,8 +131,7 @@ describe('good flags', () => {
         'skip-prompt': false,
         'project-name': 'legacy-app',
         'web-src-folder': path.resolve('/web-src'),
-        'adobe-services': undefined,
-        'skip-install': true
+        'adobe-services': undefined
       }
     })
     expect(helpers.installPackages).toHaveBeenCalledTimes(0)
@@ -150,8 +147,7 @@ describe('good flags', () => {
         'skip-prompt': false,
         'project-name': 'legacy-app',
         'web-src-folder': path.resolve('/web-src'),
-        'adobe-services': undefined,
-        'skip-install': true
+        'adobe-services': undefined
       }
     })
   })
@@ -165,8 +161,7 @@ describe('good flags', () => {
         'skip-prompt': false,
         'project-name': 'legacy-app',
         'web-src-folder': path.resolve('/web-src'),
-        'adobe-services': undefined,
-        'skip-install': true
+        'adobe-services': undefined
       }
     })
   })
@@ -181,8 +176,7 @@ describe('good flags', () => {
         'skip-prompt': false,
         'project-name': 'legacy-app',
         'web-src-folder': path.resolve('/web-src'),
-        'adobe-services': 'CampaignSDK,AdobeAnalyticsSDK',
-        'skip-install': true
+        'adobe-services': 'CampaignSDK,AdobeAnalyticsSDK'
       }
     })
   })

--- a/test/commands/app/delete/ci.test.js
+++ b/test/commands/app/delete/ci.test.js
@@ -60,8 +60,7 @@ describe('good flags', () => {
     expect(yeoman.createEnv).toHaveBeenCalled()
     expect(mockInstantiate).toHaveBeenCalledWith(expect.any(Function), {
       options: {
-        'skip-prompt': true,
-        'skip-install': true
+        'skip-prompt': true
       }
     })
   })
@@ -72,8 +71,7 @@ describe('good flags', () => {
     expect(yeoman.createEnv).toHaveBeenCalled()
     expect(mockInstantiate).toHaveBeenCalledWith(expect.any(Function), {
       options: {
-        'skip-prompt': false,
-        'skip-install': true
+        'skip-prompt': false
       }
     })
   })

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -201,15 +201,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -223,15 +223,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'otherdir', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'otherdir' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'otherdir', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'otherdir' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -248,19 +248,19 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(4)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-nui',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -273,15 +273,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-application',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -295,15 +295,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': true, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': true, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': true, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': true, force: true } }
     )
     expect(mockInstallPackages).not.toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -317,15 +317,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': true, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': true, 'project-name': 'cwd', 'skip-install': true } }
+      { options: { 'skip-prompt': true, 'project-name': 'cwd' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-nui',
-      { options: { 'skip-prompt': true, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': true, force: true } }
     )
     expect(mockInstallPackages).not.toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -371,15 +371,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -399,15 +399,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
@@ -441,15 +441,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).toHaveBeenCalled()
@@ -480,15 +480,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-nui',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).toHaveBeenCalled()
@@ -525,15 +525,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).toHaveBeenCalled()
@@ -578,15 +578,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).toHaveBeenCalled()
@@ -619,15 +619,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).toHaveBeenCalled()
@@ -658,15 +658,15 @@ describe('run', () => {
     expect(mockGenInstantiate).toHaveBeenCalledTimes(3)
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-base-app',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-add-ci',
-      { options: { 'skip-prompt': false, 'project-name': 'hola', 'skip-install': true } }
+      { options: { 'skip-prompt': false, 'project-name': 'hola' } }
     )
     expect(mockGenInstantiate).toHaveBeenCalledWith(
       'fake-gen-excshell',
-      { options: { 'skip-prompt': false, force: true, 'skip-install': true } }
+      { options: { 'skip-prompt': false, force: true } }
     )
     expect(mockInstallPackages).toHaveBeenCalled()
     expect(LibConsoleCLI.init).toHaveBeenCalled()


### PR DESCRIPTION
Fixed option `skipInstall` for yeoman generators used for scaffolding App Builder Apps
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix skipInstall options issue with yeoman generators. There is a slight change to how to use this option to make it work.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/554
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
npm dependencies seem to be installed twice once after the base-app gets generated and at the end before the app initialization is over
Expected behaviour: npm dependencies should only be installed at the end of the project initialization once the package.json deps are all defined.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally tested by creating an app - npm packages are now installed only at the end. Generators skip installing packages. All units tests run successful locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Generators skipping installing packages: 
<img width="1127" alt="image" src="https://user-images.githubusercontent.com/22499366/180777177-fb4b82b1-4517-4ae1-bc62-bca4b9b0c1ea.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
