### PR TITLE
ACNA-1634 | Replace Developer Terms of Service text with help text and Developer Console url

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "get-port": "^5.1.1",
     "hjson": "^3.2.1",
     "http-terminator": "^2.0.3",
+    "hyperlinker": "^1.0.0",
     "inquirer": "^7.0.0",
     "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -18,6 +18,7 @@ const chalk = require('chalk')
 // const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:init', { provider: 'debug' })
 const { Flags } = require('@oclif/core')
 const generators = require('@adobe/generator-aio-app')
+const hyperlinker = require('hyperlinker');
 
 const { loadAndValidateConfigFile, importConfigJson } = require('../../lib/import')
 const { atLeastOne } = require('../../lib/app-helper')
@@ -133,7 +134,7 @@ class InitCommand extends AddCommand {
     if (!isTermAccepted) {
       const terms = await consoleCLI.getDevTermsForOrg()
       const confirmDevTerms = await consoleCLI.prompt.promptConfirm(`${terms.text}
-      \nDo you agree with the new Developer Terms?`)
+      \nYou have not accepted the Developer Terms of Service. Go to ${hyperlinker('https://www.adobe.com/go/developer-terms', 'https://www.adobe.com/go/developer-terms')} to view the terms. Do you accept the terms? (y/n):`)
       if (!confirmDevTerms) {
         this.error('The Developer Terms of Service were declined')
       } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Developer Terms of Service - revert the feature partially, in that when detecting that new Dev Terms are available and not accepted, we output some help text with something to this effect, and error exit:
You have not accepted the Developer Terms for your org XYZ. Please visit https://developer.adobe.com/console/home, select your XYZ org, and accept the terms.
 
I tried to have a direct url to an org, there doesn't seem to be one, just the home screen.

We delegate the acceptance to the Developer Console.

## Related Issue

[ACNA-1634](https://jira.corp.adobe.com/browse/ACNA-1634)

## Motivation and Context

The link must always be shown for legal reasons. 

## How Has This Been Tested?
- This has been tested locally
- Unit tests are passing
- No change in coverage

## Screenshots (if appropriate):
<img width="1728" alt="Screenshot 2022-08-23 at 1 39 27 PM" src="https://user-images.githubusercontent.com/19944275/186106687-3103ad39-12cd-4775-a59a-05bca19d57bf.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
