### PR TITLE
fix: ACNA-1812 - `aio app init --no-login --extension dx/excshell/1` should not error

### DIFF
--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -113,6 +113,7 @@ class InitCommand extends TemplatesCommand {
     await this.installTemplates({
       useDefaultValues: flags.yes,
       installNpm: flags.install,
+      installConfig: flags.login,
       templates
     })
 

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -228,6 +228,7 @@ describe('--no-login', () => {
     const installOptions = {
       useDefaultValues: false,
       installNpm: true,
+      installConfig: false,
       templates: ['@adobe/my-extension']
     }
     command.selectTemplates.mockResolvedValue(['@adobe/my-extension'])
@@ -247,6 +248,7 @@ describe('--no-login', () => {
     const installOptions = {
       useDefaultValues: false,
       installNpm: true,
+      installConfig: false,
       templates: ['@adobe/my-extension']
     }
     command.selectTemplates.mockResolvedValue(['@adobe/my-extension'])
@@ -263,6 +265,7 @@ describe('--no-login', () => {
     const installOptions = {
       useDefaultValues: false,
       installNpm: true,
+      installConfig: false,
       templates: [] // stand-alone, we use the initial generators only, nothing to install from Template Registry
     }
 
@@ -278,6 +281,7 @@ describe('--no-login', () => {
     const installOptions = {
       useDefaultValues: true,
       installNpm: false,
+      installConfig: false,
       templates: ['@adobe/my-extension']
     }
     command.selectTemplates.mockResolvedValue(['@adobe/my-extension'])
@@ -294,6 +298,7 @@ describe('--no-login', () => {
     const installOptions = {
       useDefaultValues: true,
       installNpm: false,
+      installConfig: false,
       templates: ['@adobe/my-extension']
     }
 
@@ -309,6 +314,7 @@ describe('--no-login', () => {
     const installOptions = {
       useDefaultValues: true,
       installNpm: false,
+      installConfig: false,
       templates: ['@adobe/my-extension', '@adobe/your-extension']
     }
 


### PR DESCRIPTION
This is based on the master branch code, tested via the `@adobe/aio-cli-next` CLI.

The fix is passing a flag to the `templates` plugin to not process the template install.yml config, which requires a user login.

Closes #582 

## How Has This Been Tested?

- npm test
- manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
