### PR TITLE
fix: ACNA-1807 - remove deprecated flags in the commands

### DIFF
--- a/src/commands/app/build.js
+++ b/src/commands/app/build.js
@@ -26,8 +26,7 @@ class Build extends BaseCommand {
     // cli input
     const { flags } = await this.parse(Build)
     // flags
-    flags['web-assets'] = flags['web-assets'] && !flags['skip-static'] && !flags['skip-web-assets'] && !flags.action
-    flags.actions = flags.actions && !flags['skip-actions']
+    flags['web-assets'] = flags['web-assets'] && !flags.action
 
     const buildConfigs = this.getAppExtConfigs(flags)
 
@@ -144,15 +143,6 @@ This will always force a rebuild unless --no-force-build is set.
 
 Build.flags = {
   ...BaseCommand.flags,
-  'skip-static': Flags.boolean({
-    description: '[deprecated] Please use --no-web-assets'
-  }),
-  'skip-web-assets': Flags.boolean({
-    description: '[deprecated] Please use --no-web-assets'
-  }),
-  'skip-actions': Flags.boolean({
-    description: '[deprecated] Please use --no-actions'
-  }),
   actions: Flags.boolean({
     description: '[default: true] Build actions if any',
     default: true,

--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -33,8 +33,6 @@ class Run extends BaseCommand {
   async run () {
     // cli input
     const { flags } = await this.parse(Run)
-    // aliases
-    flags.actions = flags.actions && !flags['skip-actions']
 
     const spinner = ora()
 
@@ -64,8 +62,8 @@ class Run extends BaseCommand {
     if (!hasBackend && !hasFrontend) {
       this.error(new Error('nothing to run.. there is no frontend and no manifest.yml, are you in a valid app?'))
     }
-    if (flags['skip-actions'] && !hasFrontend) {
-      this.error(new Error('nothing to run.. there is no frontend and --skip-actions is set'))
+    if (!flags.actions && !hasFrontend) {
+      this.error(new Error('nothing to run.. there is no frontend and --no-actions is set'))
     }
 
     const runOptions = {
@@ -203,22 +201,16 @@ Run.description = 'Run an Adobe I/O App'
 Run.flags = {
   ...BaseCommand.flags,
   local: Flags.boolean({
-    description: 'Run/debug actions locally ( requires Docker running )',
-    exclusive: ['skip-actions']
+    description: 'Run/debug actions locally (requires Docker running)',
+    exclusive: ['no-actions']
   }),
   serve: Flags.boolean({
     description: '[default: true] Start frontend server (experimental)',
     default: true,
     allowNo: true
   }),
-  'skip-actions': Flags.boolean({
-    description: '[deprecated] Please use --no-actions',
-    exclusive: ['local'],
-    default: false
-  }),
   actions: Flags.boolean({
     description: '[default: true] Run actions, defaults to true, to skip actions use --no-actions',
-    exclusive: ['local'], // no-actions and local don't work together
     default: true,
     allowNo: true
   }),

--- a/src/commands/app/undeploy.js
+++ b/src/commands/app/undeploy.js
@@ -26,10 +26,6 @@ class Undeploy extends BaseCommand {
     // cli input
     const { flags } = await this.parse(Undeploy)
 
-    // flags
-    flags['web-assets'] = flags['web-assets'] && !flags['skip-static'] && !flags['skip-web-assets'] && !flags.action
-    flags.actions = flags.actions && !flags['skip-actions']
-
     const undeployConfigs = this.getAppExtConfigs(flags)
     let libConsoleCLI
     if (flags.unpublish) {
@@ -146,15 +142,6 @@ Undeploy.description = `Undeploys an Adobe I/O App
 
 Undeploy.flags = {
   ...BaseCommand.flags,
-  'skip-static': Flags.boolean({
-    description: '[deprecated] Please use --no-web-assets'
-  }),
-  'skip-web-assets': Flags.boolean({
-    description: '[deprecated] Please use --no-web-assets'
-  }),
-  'skip-actions': Flags.boolean({
-    description: '[deprecated] Please use --no-actions'
-  }),
   actions: Flags.boolean({
     description: '[default: true] Undeploy actions if any',
     default: true,

--- a/test/commands/app/build.test.js
+++ b/test/commands/app/build.test.js
@@ -172,15 +172,6 @@ test('flags', async () => {
   expect(typeof TheCommand.flags.action.description).toBe('string')
   expect(TheCommand.flags.action.exclusive).toEqual(['extension'])
 
-  expect(typeof TheCommand.flags['skip-actions']).toBe('object')
-  expect(typeof TheCommand.flags['skip-actions'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-static']).toBe('object')
-  expect(typeof TheCommand.flags['skip-static'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-web-assets']).toBe('object')
-  expect(typeof TheCommand.flags['skip-web-assets'].description).toBe('string')
-
   expect(typeof TheCommand.flags.actions).toBe('object')
   expect(typeof TheCommand.flags.actions.description).toBe('string')
   expect(TheCommand.flags.actions.exclusive).toEqual(['action'])
@@ -317,18 +308,9 @@ describe('run', () => {
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(1)
   })
 
-  test('build & deploy --skip-static', async () => {
+  test('build & deploy --no-web-assets', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
-    command.argv = ['--skip-static']
-    await command.run()
-    expect(command.error).toHaveBeenCalledTimes(0)
-    expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(1)
-    expect(mockWebLib.bundle).toHaveBeenCalledTimes(0)
-  })
-
-  test('build & deploy --skip-web-assets', async () => {
-    command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
-    command.argv = ['--skip-web-assets']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(1)
@@ -338,7 +320,7 @@ describe('run', () => {
   test('build & deploy only some actions using --action', async () => {
     const appConfig = createAppConfig(command.appConfig)
     command.getAppExtConfigs.mockReturnValueOnce(appConfig)
-    command.argv = ['--skip-static', '-a', 'a', '-a=b', '--action', 'c']
+    command.argv = ['--no-web-assets', '-a', 'a', '-a=b', '--action', 'c']
     mockRuntimeLib.buildActions.mockReturnValue(['a', 'b', 'c'])
     await command.run()
     expect(spinner.start).toBeCalledWith('Building actions for \'application\'')
@@ -361,10 +343,10 @@ describe('run', () => {
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(1)
   })
 
-  test('build & deploy with --skip-actions', async () => {
+  test('build & deploy with --no-actions', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     mockFS.existsSync.mockReturnValue(true)
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
@@ -372,12 +354,12 @@ describe('run', () => {
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(0)
   })
 
-  test('build & deploy with --skip-actions with no frontend', async () => {
+  test('build & deploy with --no-actions with no frontend', async () => {
     command.appConfig.app.hasFrontend = false
     command.appConfig.app.hasBackend = true
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(0)
@@ -442,7 +424,7 @@ describe('run', () => {
     expect(scriptSequence[3]).toEqual('post-app-build')
   })
 
-  test('build (--skip-actions and --skip-static)', async () => {
+  test('build (--no-actions and --no-web-assets)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     const noScriptFound = undefined
@@ -450,13 +432,13 @@ describe('run', () => {
       .mockResolvedValueOnce(noScriptFound) // pre-app-build
       .mockResolvedValueOnce(noScriptFound) // post-app-build
 
-    command.argv = ['--skip-actions', '--skip-static']
+    command.argv = ['--no-actions', '--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(1)
     expect(command.error).toHaveBeenCalledWith(expect.stringMatching(/Nothing to be done/))
   })
 
-  test('build (--skip-actions)', async () => {
+  test('build (--no-actions)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     mockWebLib.bundle.mockImplementation((a, b, c, log) => {
@@ -469,14 +451,14 @@ describe('run', () => {
       .mockResolvedValueOnce(noScriptFound) // pre-app-build
       .mockResolvedValueOnce(noScriptFound) // post-app-build
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(1)
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(0)
   })
 
-  test('build (--skip-actions, --verbose) (coverage)', async () => {
+  test('build (--no-actions, --verbose) (coverage)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     mockWebLib.bundle.mockImplementation((a, b, c, log) => {
@@ -489,14 +471,14 @@ describe('run', () => {
       .mockResolvedValueOnce(noScriptFound) // pre-app-build
       .mockResolvedValueOnce(noScriptFound) // post-app-build
 
-    command.argv = ['--skip-actions', '--verbose']
+    command.argv = ['--no-actions', '--verbose']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(1)
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(0)
   })
 
-  test('build (--skip-static)', async () => {
+  test('build (--no-web-assets)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     const noScriptFound = undefined
@@ -504,7 +486,7 @@ describe('run', () => {
       .mockResolvedValueOnce(noScriptFound) // pre-app-build
       .mockResolvedValueOnce(noScriptFound) // post-app-build
 
-    command.argv = ['--skip-static']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(0)
@@ -528,14 +510,14 @@ describe('run', () => {
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(0)
   })
 
-  test('build (pre and post hooks have errors, --skip-actions and --skip-static)', async () => {
+  test('build (pre and post hooks have errors, --no-actions and --no-web-assets)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     helpers.runScript
       .mockRejectedValueOnce('error-pre-app-build') // pre-app-build (logs error)
       .mockRejectedValueOnce('error-post-app-build') // post-app-build (logs error)
 
-    command.argv = ['--skip-actions', '--skip-static']
+    command.argv = ['--no-actions', '--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(1) // nothing to be done, because of the flags
     expect(command.error).toHaveBeenCalledWith(expect.stringMatching(/Nothing to be done/))

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -192,21 +192,6 @@ test('flags', async () => {
   expect(typeof TheCommand.flags.action.description).toBe('string')
   expect(TheCommand.flags.action.exclusive).toEqual(['extension'])
 
-  expect(typeof TheCommand.flags['skip-actions']).toBe('object')
-  expect(typeof TheCommand.flags['skip-actions'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-static']).toBe('object')
-  expect(typeof TheCommand.flags['skip-static'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-web-assets']).toBe('object')
-  expect(typeof TheCommand.flags['skip-web-assets'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-deploy']).toBe('object')
-  expect(typeof TheCommand.flags['skip-deploy'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-build']).toBe('object')
-  expect(typeof TheCommand.flags['skip-build'].description).toBe('string')
-
   expect(typeof TheCommand.flags['web-assets']).toBe('object')
   expect(typeof TheCommand.flags['web-assets'].description).toBe('string')
   expect(TheCommand.flags['web-assets'].default).toEqual(true)
@@ -316,44 +301,31 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, verbose: true }), expect.anything())
   })
 
-  test('build & deploy --skip-static', async () => {
+  test('build & deploy --no-web-assets', async () => {
     const appConfig = createAppConfig(command.appConfig)
     command.getAppExtConfigs.mockReturnValueOnce(appConfig)
 
-    command.argv = ['--skip-static']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'skip-static': true }), expect.anything())
-  })
-
-  test('build & deploy --skip-web-assets', async () => {
-    const appConfig = createAppConfig(command.appConfig)
-    command.getAppExtConfigs.mockReturnValueOnce(appConfig)
-
-    command.argv = ['--skip-web-assets']
-    await command.run()
-    expect(command.error).toHaveBeenCalledTimes(0)
-    expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
-    expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
-    expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'skip-web-assets': true }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false }), expect.anything())
   })
 
   test('build & deploy only some actions using --action', async () => {
     const appConfig = createAppConfig(command.appConfig)
     command.getAppExtConfigs.mockReturnValueOnce(appConfig)
 
-    command.argv = ['--skip-static', '-a', 'a', '-a', 'b', '--action', 'c']
+    command.argv = ['--no-web-assets', '-a', 'a', '-a', 'b', '--action', 'c']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
 
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'skip-static': true, action: ['a', 'b', 'c'] }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false, action: ['a', 'b', 'c'] }), expect.anything())
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(appConfig.application, {
       filterEntities: { actions: ['a', 'b', 'c'] }
     },
@@ -366,19 +338,19 @@ describe('run', () => {
     const appConfig = createAppConfig(command.appConfig)
     command.getAppExtConfigs.mockReturnValueOnce(appConfig)
 
-    command.argv = ['--skip-static']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'skip-static': true }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false }), expect.anything())
   })
 
   test('build & deploy actions with no actions folder but with a manifest', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-static']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
@@ -386,32 +358,32 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
   })
 
-  test('build & deploy with --skip-actions', async () => {
+  test('build & deploy with --no-actions', async () => {
     const appConfig = createAppConfig(command.appConfig)
     command.getAppExtConfigs.mockReturnValueOnce(appConfig)
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'skip-actions': true }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, actions: false }), expect.anything())
   })
 
-  test('build & deploy with --skip-actions with no static folder', async () => {
+  test('build & deploy with --no-actions with no static folder', async () => {
     command.appConfig.app.hasFrontend = false
     command.appConfig.app.hasBackend = false
     const appConfig = createAppConfig(command.appConfig)
     command.getAppExtConfigs.mockReturnValueOnce(appConfig)
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'skip-actions': true }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, actions: false }), expect.anything())
   })
 
   test('build & deploy with no manifest.yml', async () => {
@@ -428,46 +400,10 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true }), expect.anything())
   })
 
-  test('--skip-deploy', async () => {
-    const appConfig = createAppConfig(command.appConfig)
-    command.getAppExtConfigs.mockReturnValueOnce(appConfig)
-
-    command.argv = ['--skip-deploy']
-    await command.run()
-    expect(command.error).not.toHaveBeenCalled()
-    expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
-    expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true }), expect.anything())
-  })
-
-  test('--skip-deploy --verbose', async () => {
-    const appConfig = createAppConfig(command.appConfig)
-    command.getAppExtConfigs.mockReturnValueOnce(appConfig)
-
-    command.argv = ['--skip-deploy', '--verbose']
-    await command.run()
-    expect(command.error).toHaveBeenCalledTimes(0)
-    expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
-    expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
-    expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, verbose: true }), expect.anything())
-  })
-
-  test('--skip-deploy --skip-static', async () => {
+  test('--no-build', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-deploy', '--skip-static']
-    await command.run()
-    expect(command.error).toHaveBeenCalledTimes(0)
-    expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
-    expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
-    expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-  })
-
-  test('--skip-build', async () => {
-    command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
-
-    command.argv = ['--skip-build']
+    command.argv = ['--no-build']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
@@ -475,10 +411,10 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledTimes(0)
   })
 
-  test('--skip-build --verbose', async () => {
+  test('--no-build --verbose', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-build', '--verbose']
+    command.argv = ['--no-build', '--verbose']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
@@ -486,10 +422,10 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledTimes(0)
   })
 
-  test('--skip-build --skip-actions', async () => {
+  test('--no-build --no-actions', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-build', '--skip-actions']
+    command.argv = ['--no-build', '--no-actions']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
@@ -497,10 +433,10 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledTimes(0)
   })
 
-  test('--skip-build --skip-static', async () => {
+  test('--no-build --no-web-assets', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
-    command.argv = ['--skip-build', '--skip-static']
+    command.argv = ['--no-build', '--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
@@ -678,14 +614,14 @@ describe('run', () => {
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
   })
 
-  test('deploy (--skip-actions and --skip-static) for application - nothing to be done', async () => {
+  test('deploy (--no-actions and --no-web-assets) for application - nothing to be done', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
     const noScriptFound = undefined
     helpers.runScript
       .mockResolvedValueOnce(noScriptFound) // pre-app-deploy
       .mockResolvedValueOnce(noScriptFound) // post-app-deploy
 
-    command.argv = ['--skip-actions', '--skip-static']
+    command.argv = ['--no-actions', '--no-web-assets']
     await command.run()
 
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
@@ -693,7 +629,7 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledWith('Nothing to be done 🚫')
   })
 
-  test('deploy (--skip-actions and --skip-static) for extension - publish', async () => {
+  test('deploy (--no-actions and --no-web-assets) for extension - publish', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig, 'exc'))
     command.getFullConfig.mockReturnValue({
       aio: {
@@ -710,7 +646,7 @@ describe('run', () => {
       .mockResolvedValueOnce(noScriptFound) // pre-app-deploy
       .mockResolvedValueOnce(noScriptFound) // post-app-deploy
 
-    command.argv = ['--skip-actions', '--skip-static']
+    command.argv = ['--no-actions', '--no-web-assets']
     await command.run()
 
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
@@ -719,28 +655,28 @@ describe('run', () => {
     expect(mockLibConsoleCLI.updateExtensionPointsWithoutOverwrites).toHaveBeenCalledTimes(1)
   })
 
-  test('deploy (--skip-actions)', async () => {
+  test('deploy (--no-actions)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
     const noScriptFound = undefined
     helpers.runScript
       .mockResolvedValueOnce(noScriptFound) // pre-app-deploy
       .mockResolvedValueOnce(noScriptFound) // post-app-deploy
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     await command.run()
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.error).toHaveBeenCalledTimes(0)
   })
 
-  test('deploy (--skip-static)', async () => {
+  test('deploy (--no-web-assets)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
     const noScriptFound = undefined
     helpers.runScript
       .mockResolvedValueOnce(noScriptFound) // pre-app-deploy
       .mockResolvedValueOnce(noScriptFound) // post-app-deploy
 
-    command.argv = ['--skip-static']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
@@ -812,15 +748,6 @@ describe('run', () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     command.argv = ['--no-publish', '--no-web-assets', '--no-actions']
-    await command.run()
-    expect(command.error).toHaveBeenCalledTimes(1)
-    expect(command.error).toHaveBeenCalledWith(expect.stringMatching(/Nothing to be done/))
-  })
-
-  test('nothing to be done for exc (--no-publish, --no-build, --skip-deploy)', async () => {
-    command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig, 'exc'))
-
-    command.argv = ['--no-publish', '--no-build', '--skip-deploy']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(1)
     expect(command.error).toHaveBeenCalledWith(expect.stringMatching(/Nothing to be done/))

--- a/test/commands/app/run.test.js
+++ b/test/commands/app/run.test.js
@@ -150,20 +150,15 @@ describe('run command definition', () => {
   test('flags', async () => {
     expect(typeof TheCommand.flags.local).toBe('object')
     expect(typeof TheCommand.flags.local.description).toBe('string')
-    expect(TheCommand.flags.local.exclusive).toEqual(['skip-actions'])
+    expect(TheCommand.flags.local.exclusive).toEqual(['no-actions'])
 
     expect(typeof TheCommand.flags.serve).toBe('object')
     expect(typeof TheCommand.flags.serve.description).toBe('string')
     expect(TheCommand.flags.serve.default).toEqual(true)
     expect(TheCommand.flags.serve.allowNo).toEqual(true)
 
-    expect(typeof TheCommand.flags['skip-actions']).toBe('object')
-    expect(typeof TheCommand.flags['skip-actions'].description).toBe('string')
-    expect(TheCommand.flags['skip-actions'].exclusive).toEqual(['local'])
-
     expect(typeof TheCommand.flags.actions).toBe('object')
     expect(typeof TheCommand.flags.actions.description).toBe('string')
-    expect(TheCommand.flags.actions.exclusive).toEqual(['local'])
     expect(TheCommand.flags.actions.default).toEqual(true)
     expect(TheCommand.flags.actions.allowNo).toEqual(true)
 
@@ -211,18 +206,18 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledWith(Error('nothing to run.. there is no frontend and no manifest.yml, are you in a valid app?'))
   })
 
-  test('app:run with no web-src and --skip-actions should fail', async () => {
-    command.argv = ['--skip-actions']
+  test('app:run with no web-src and --no-actions should fail', async () => {
+    command.argv = ['--no-actions']
     command.appConfig.app.hasFrontend = false
     command.appConfig.app.hasBackend = true
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig))
 
     await command.run()
-    expect(command.error).toHaveBeenCalledWith(Error('nothing to run.. there is no frontend and --skip-actions is set'))
-    // await expect(command.run()).rejects.toThrow('nothing to run.. there is no frontend and --skip-actions is set')
+    expect(command.error).toHaveBeenCalledWith(Error('nothing to run.. there is no frontend and --no-actions is set'))
+    // await expect(command.run()).rejects.toThrow('nothing to run.. there is no frontend and --no-actions is set')
   })
 
-  test('app:run with web-src and --skip-actions', async () => {
+  test('app:run with web-src and --no-actions', async () => {
     command.argv = []
     command.appConfig.app.hasFrontend = false
     command.appConfig.app.hasBackend = true

--- a/test/commands/app/undeploy.test.js
+++ b/test/commands/app/undeploy.test.js
@@ -83,15 +83,6 @@ test('aliases', async () => {
 })
 
 test('flags', async () => {
-  expect(typeof TheCommand.flags['skip-actions']).toBe('object')
-  expect(typeof TheCommand.flags['skip-actions'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-static']).toBe('object')
-  expect(typeof TheCommand.flags['skip-static'].description).toBe('string')
-
-  expect(typeof TheCommand.flags['skip-web-assets']).toBe('object')
-  expect(typeof TheCommand.flags['skip-web-assets'].description).toBe('string')
-
   expect(typeof TheCommand.flags.actions).toBe('object')
   expect(typeof TheCommand.flags.actions.description).toBe('string')
   expect(TheCommand.flags.actions.default).toEqual(true)
@@ -168,14 +159,14 @@ describe('run', () => {
     expect(mockWebLib.undeployWeb).toHaveBeenCalledTimes(0)
   })
 
-  test('pre post undeploy hook errors --skip-actions --skip-static', async () => {
+  test('pre post undeploy hook errors --no-actions --no-web-assets', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
     helpers.runScript
       .mockRejectedValueOnce('error-pre-app-undeploy') // pre-app-deploy (logs error)
       .mockRejectedValueOnce('error-post-app-undeploy') // post-app-deploy (logs error)
 
-    command.argv = ['--skip-actions', '--skip-static']
+    command.argv = ['--no-actions', '--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.undeployActions).toHaveBeenCalledTimes(0)
@@ -195,20 +186,20 @@ describe('run', () => {
     expect(mockWebLib.undeployWeb).toHaveBeenCalledTimes(1)
   })
 
-  test('undeploy skip-actions', async () => {
+  test('undeploy no-actions', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
-    command.argv = ['--skip-actions']
+    command.argv = ['--no-actions']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.undeployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.undeployWeb).toHaveBeenCalledTimes(1)
   })
 
-  test('undeploy skip-actions verbose', async () => {
+  test('undeploy no-actions verbose', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
-    command.argv = ['--skip-actions', '-v']
+    command.argv = ['--no-actions', '-v']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.undeployActions).toHaveBeenCalledTimes(0)
@@ -218,7 +209,7 @@ describe('run', () => {
   test('undeploy skip static', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
-    command.argv = ['--skip-static']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.undeployActions).toHaveBeenCalledTimes(1)
@@ -228,7 +219,7 @@ describe('run', () => {
   test('undeploy skip web assets', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
-    command.argv = ['--skip-web-assets']
+    command.argv = ['--no-web-assets']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.undeployActions).toHaveBeenCalledTimes(1)
@@ -238,7 +229,7 @@ describe('run', () => {
   test('undeploy skip static verbose', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
-    command.argv = ['--skip-static', '-v']
+    command.argv = ['--no-web-assets', '-v']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.undeployActions).toHaveBeenCalledTimes(1)
@@ -402,7 +393,7 @@ describe('run', () => {
     expect(scriptSequence[3]).toEqual('post-app-undeploy')
   })
 
-  test('nothing to be undeployed (--no-publish, --build, --skip-deploy)', async () => {
+  test('nothing to be undeployed (--no-publish, --build, --no-deploy)', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig())
 
     command.argv = ['--no-unpublish', '--no-web-assets', '--no-actions']


### PR DESCRIPTION
There have been deprecated flags in the app plugin. e.g. `--skip-???` that already have other flag equivalents. 
Removal of these flags is a `breaking change`, thus a `major version bump` to v10.

For the `app deploy` command I didn't change `skip-deploy` to `deploy` with `allowNo:true` because it didn't make sense at all, and removed any tests for `skip-deploy`.

## How Has This Been Tested?

manual testing of app:
- deploy 
- undeploy
- build
-  run

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
