### PR TITLE
fix: ACNA-1817 - error when trying to deploy an app created with `aio app init --no-login`

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -82,7 +82,7 @@ class Deploy extends BuildCommand {
       }
 
       // 2. Bail if workspace is production and application status is PUBLISHED, honor force-deploy
-      if (aioConfig.project.workspace.name === 'Production' && !flags['force-deploy']) {
+      if (aioConfig?.project?.workspace?.name === 'Production' && !flags['force-deploy']) {
         const extension = await this.getApplicationExtension(libConsoleCLI, aioConfig)
         spinner.info(chalk.dim(JSON.stringify(extension)))
         if (extension && extension.status === 'PUBLISHED') {

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -753,6 +753,26 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledWith(expect.stringMatching(/Nothing to be done/))
   })
 
+  test('deploy for standalone app --no-publish (no login)', async () => {
+    command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig, 'exc'))
+    mockGetExtensionPointsPublishedApp()
+    mockGetProject()
+    command.getFullConfig.mockReturnValue({
+      aio: {
+      }
+    })
+    mockExtRegExcShellPayload()
+    command.argv = ['--no-publish']
+    await command.run()
+
+    expect(mockLibConsoleCLI.getProject).toHaveBeenCalledTimes(0)
+    expect(mockLibConsoleCLI.getApplicationExtensions).toHaveBeenCalledTimes(0)
+    expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
+    expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
+    expect(mockLibConsoleCLI.updateExtensionPoints).toHaveBeenCalledTimes(0)
+    expect(mockLibConsoleCLI.updateExtensionPointsWithoutOverwrites).toHaveBeenCalledTimes(0)
+  })
+
   test('deploy for PUBLISHED Production extension - no publish', async () => {
     command.getAppExtConfigs.mockReturnValueOnce(createAppConfig(command.appConfig, 'exc'))
     mockGetExtensionPointsPublishedApp()


### PR DESCRIPTION
fixes #587 

## How Has This Been Tested?

1. `npm test`
2. `aio plugins link .` (in the app plugin folder of this PR branch)

### Scenario 1:

1. ` aio app init my-app-1 --no-login --yes --standalone-app`
2. `cd my-app`
3. `aio app deploy`

### Scenario 2:

1. `aio app init my-app-2 --no-login --yes --extension dx/excshell/1`
2. `cd my-app`
3. `aio app deploy --no-publish`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
