### PR TITLE
fix: init standalone-app if no templates are selected

### DIFF
--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -104,6 +104,10 @@ class InitCommand extends TemplatesCommand {
 
     // 2. prompt for templates to be installed
     const templates = await this.getTemplatesForFlags(flags)
+    // If no templates selected, init a standalone app
+    if (templates.length <= 0) {
+      flags['standalone-app'] = true
+    }
 
     // 3. run base code generators
     const projectName = (consoleConfig && consoleConfig.project.name) || path.basename(process.cwd())
@@ -138,6 +142,10 @@ class InitCommand extends TemplatesCommand {
 
     // 5. get list of templates to install
     const templates = await this.getTemplatesForFlags(flags, orgSupportedServices)
+    // If no templates selected, init a standalone app
+    if (templates.length <= 0) {
+      flags['standalone-app'] = true
+    }
 
     // 6. download workspace config
     const consoleConfig = await consoleCLI.getWorkspaceConfig(org.id, project.id, workspace.id, orgSupportedServices)


### PR DESCRIPTION
## Description

If the user does not select any templates, initialize a standalone application. 

## Related Issue
closes https://github.com/adobe/aio-cli-plugin-app/issues/591

## Motivation and Context

This fixes a workflow that results in an un-deployable App Builder application.

## How Has This Been Tested?

* Locally linked app plugin 
* Locally ran `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
