### PR TITLE
Call in-process hook for deploy-action with parameters

### DIFF
--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -104,8 +104,8 @@ class Run extends BaseCommand {
         spinner.info(chalk.dim(`${info}`))
         spinner.start()
       }
-
-    const frontendUrl = await runDev(config, this.config.dataDir, runOptions, onProgress)
+    const inprocHook = this.config.runHook.bind(this.config)
+    const frontendUrl = await runDev(config, this.config.dataDir, runOptions, onProgress, inprocHook)
     try {
       await runScript(config.hooks['post-app-run'])
     } catch (err) {

--- a/src/lib/actions-watcher.js
+++ b/src/lib/actions-watcher.js
@@ -61,10 +61,9 @@ module.exports = async (watcherOptions) => {
  * @param {Array<string>} filterActions add filters to deploy only specified OpenWhisk actions
  */
 async function buildAndDeploy (watcherOptions, filterActions) {
-  const { config, isLocal, log } = watcherOptions
-
+  const { config, isLocal, log, inprocHook } = watcherOptions
   await buildActions(config, filterActions)
-  await deployActions(config, isLocal, log, filterActions)
+  await deployActions(config, isLocal, log, filterActions, inprocHook)
 }
 
 /**

--- a/src/lib/deploy-actions.js
+++ b/src/lib/deploy-actions.js
@@ -22,7 +22,7 @@ const { deployActions } = require('@adobe/aio-lib-runtime')
  * @param {boolean} filter true if a filter by built actions is desired.
  */
 /** @private */
-module.exports = async (config, isLocalDev = false, log = () => {}, filter = false) => {
+module.exports = async (config, isLocalDev = false, log = () => {}, filter = false, inprocHook) => {
   utils.runScript(config.hooks['pre-app-deploy'])
   const script = await utils.runScript(config.hooks['deploy-actions'])
   if (!script) {
@@ -31,6 +31,14 @@ module.exports = async (config, isLocalDev = false, log = () => {}, filter = fal
       filterEntities: {
         byBuiltActions: filter
       }
+    }
+    if (inprocHook) {
+      const hookFilterEntities = Array.isArray(filter) ? filter : []
+      await inprocHook('deploy-actions', {
+        appConfig: config,
+        filterEntities: hookFilterEntities,
+        isLocalDev
+      })
     }
     const entities = await deployActions(config, deployConfig, log)
     if (entities.actions) {

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -30,7 +30,7 @@ const { run: logPoller } = require('./log-poller')
 const getPort = require('get-port')
 
 /** @private */
-async function runDev (config, dataDir, options = {}, log = () => {}) {
+async function runDev (config, dataDir, options = {}, log = () => {}, inprocHook) {
   /* parcel bundle options */
   const bundleOptions = {
     shouldDisableCache: true,
@@ -38,6 +38,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}) {
     shouldOptimize: false,
     ...options.parcel
   }
+
   /* skip actions */
   const skipActions = !!options.skipActions
   /* fetch logs for actions option */
@@ -48,6 +49,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}) {
   const withBackend = config.app.hasBackend && !skipActions
   const isLocal = options.isLocal // applies only for backend
   const portToUse = parseInt(process.env.PORT) || SERVER_DEFAULT_PORT
+
   const uiPort = await getPort({ port: portToUse })
   if (uiPort !== portToUse) {
     log(`Could not use port:${portToUse}, using port:${uiPort} instead`)
@@ -82,7 +84,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}) {
       log('building actions..')
       await buildActions(devConfig, null, true /* force build */)
 
-      const { cleanup: watcherCleanup } = await actionsWatcher({ config: devConfig, isLocal, log })
+      const { cleanup: watcherCleanup } = await actionsWatcher({ config: devConfig, isLocal, log, inprocHook })
       cleanup.add(() => watcherCleanup(), 'stopping action watcher...')
     }
 
@@ -121,7 +123,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}) {
     // Deploy Phase - deploy actions
     if (withBackend) {
       log('redeploying actions..')
-      await deployActions(devConfig, isLocal, log, true)
+      await deployActions(devConfig, isLocal, log, true, inprocHook)
     }
 
     // Deploy Phase - serve the web UI
@@ -155,6 +157,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}) {
     }
     cleanup.wait()
   } catch (e) {
+    console.log('Error : ', e.stack)
     aioLogger.error('unexpected error, cleaning up...')
     await cleanup.run()
     throw e

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -252,7 +252,7 @@ describe('run', () => {
     command.appConfig = cloneDeep(mockConfigData)
     command.appConfig.actions = { dist: 'actions' }
     command.appConfig.web.distProd = 'dist'
-    command.config = { runCommand: jest.fn() }
+    command.config = { runCommand: jest.fn(), runHook: jest.fn() }
     command.buildOneExt = jest.fn()
     command.getAppExtConfigs = jest.fn()
     command.getLibConsoleCLI = jest.fn(() => mockLibConsoleCLI)
@@ -710,6 +710,13 @@ describe('run', () => {
 
     command.argv = []
     await command.run()
+    expect(command.config.runHook).toHaveBeenCalledTimes(1)
+    expect(command.config.runHook).toHaveBeenCalledWith('deploy-actions',
+      expect.objectContaining({
+        appConfig: expect.any(Object),
+        filterEntities: [],
+        isLocalDev: false
+      }))
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.error).toHaveBeenCalledTimes(0)

--- a/test/commands/app/run.test.js
+++ b/test/commands/app/run.test.js
@@ -108,6 +108,7 @@ beforeEach(() => {
   command.error = jest.fn()
   command.log = jest.fn()
   command.config = {
+    runHook: jest.fn(),
     findCommand: jest.fn().mockReturnValue({
       load: mockFindCommandLoad
     }),
@@ -280,7 +281,7 @@ describe('run', () => {
         logLevel: 'warn'
       }),
       isLocal: undefined
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
   })
 
   test('app:run check if fetchLogs flag is set when calling scripts', async () => {
@@ -292,7 +293,7 @@ describe('run', () => {
     await command.run()
     expect(mockRunDev).toHaveBeenCalledWith(appConfig.application, expect.any(String), expect.objectContaining({
       fetchLogs: true
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
   })
 
   test('app:run with --verbose', async () => {
@@ -309,7 +310,7 @@ describe('run', () => {
         logLevel: 'verbose'
       }),
       isLocal: undefined
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
   })
 
   test('app:run with --local', async () => {
@@ -339,7 +340,7 @@ describe('run', () => {
         logLevel: 'verbose'
       }),
       isLocal: true
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
   })
 
   test('app:run where scripts.runDev throws', async () => {
@@ -423,7 +424,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
   })
 
   test('app:run with UI and no cert files but has cert config', async () => {
@@ -446,7 +447,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
     expect(mockFS.ensureDir).toHaveBeenCalledWith(DEV_KEYS_DIR)
     expect(mockFS.writeFile).toHaveBeenCalledTimes(2)
     expect(mockFS.writeFile).toHaveBeenCalledWith(PUB_CERT_PATH, 'pub cert')
@@ -477,7 +478,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
     expect(mockFS.ensureDir).toHaveBeenCalledWith(DEV_KEYS_DIR)
     expect(command.config.findCommand).toHaveBeenCalledWith('certificate:generate')
     expect(mockFindCommandRun).toHaveBeenCalledWith([`--keyout=${PRIVATE_KEY_PATH}`, `--out=${PUB_CERT_PATH}`, '-n=DeveloperSelfSigned.cert'])
@@ -515,7 +516,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
     expect(mockConfig.set).toHaveBeenCalledTimes(2)
     expect(mockConfig.set).toHaveBeenCalledWith(CONFIG_KEY + '.privateKey', 'private key')
     expect(mockConfig.set).toHaveBeenCalledWith(CONFIG_KEY + '.publicCert', 'public cert')
@@ -555,7 +556,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
     expect(https.createServer).toHaveBeenCalledWith({ key: 'private key', cert: 'public cert' }, expect.any(Function))
     expect(getPort).toHaveBeenCalledWith({ port: SERVER_DEFAULT_PORT })
     expect(mockHttpsServerInstance.listen).toHaveBeenCalledWith(1111)
@@ -593,7 +594,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
     expect(getPort).toHaveBeenCalledWith({ port: 9999 })
     expect(mockHttpsServerInstance.listen).toHaveBeenCalledWith(1111)
     expect(cli.open).toHaveBeenCalledWith('https://localhost:1111')
@@ -632,7 +633,7 @@ describe('run', () => {
           key: PRIVATE_KEY_PATH
         }
       }
-    }), expect.any(Function))
+    }), expect.any(Function), expect.any(Function))
     expect(mockHttpsServerInstance.listen).toHaveBeenCalledWith(1111)
     expect(mockHttpsServerInstance.close).toHaveBeenCalledTimes(1)
     expect(cli.open).toHaveBeenCalledWith('https://localhost:1111')

--- a/test/commands/lib/deploy-actions.test.js
+++ b/test/commands/lib/deploy-actions.test.js
@@ -84,7 +84,48 @@ test('it should deploy actions with filter param, (coverage)', async () => {
 
 test('no deploy-actions app hook available (use inbuilt)', async () => {
   await deployActions({ hooks: {} })
+  expect(rtDeployActions).toHaveBeenCalled()
+  expect(utils.runScript).toHaveBeenNthCalledWith(1, undefined) // pre-app-deploy
+  expect(utils.runScript).toHaveBeenNthCalledWith(2, undefined) // deploy-actions
+  expect(utils.runScript).toHaveBeenNthCalledWith(3, undefined) // post-app-deploy
+})
 
+test('call inprocHook no filter', async () => {
+  const mockHook = jest.fn()
+  await deployActions({ hooks: {} }, false, null, false, mockHook)
+  expect(mockHook).toHaveBeenCalledWith('deploy-actions', expect.objectContaining({
+    appConfig: { hooks: {} },
+    filterEntities: [],
+    isLocalDev: false
+  }))
+  expect(rtDeployActions).toHaveBeenCalled()
+  expect(utils.runScript).toHaveBeenNthCalledWith(1, undefined) // pre-app-deploy
+  expect(utils.runScript).toHaveBeenNthCalledWith(2, undefined) // deploy-actions
+  expect(utils.runScript).toHaveBeenNthCalledWith(3, undefined) // post-app-deploy
+})
+
+test('call inprocHook with filter : isLocalDev false', async () => {
+  const mockHook = jest.fn()
+  await deployActions({ hooks: {} }, false, null, ['boomer'], mockHook)
+  expect(mockHook).toHaveBeenCalledWith('deploy-actions', expect.objectContaining({
+    appConfig: { hooks: {} },
+    filterEntities: ['boomer'],
+    isLocalDev: false
+  }))
+  expect(rtDeployActions).toHaveBeenCalled()
+  expect(utils.runScript).toHaveBeenNthCalledWith(1, undefined) // pre-app-deploy
+  expect(utils.runScript).toHaveBeenNthCalledWith(2, undefined) // deploy-actions
+  expect(utils.runScript).toHaveBeenNthCalledWith(3, undefined) // post-app-deploy
+})
+
+test('call inprocHook with filter : isLocalDev true', async () => {
+  const mockHook = jest.fn()
+  await deployActions({ hooks: {} }, true, null, ['action-1', 'action-2'], mockHook)
+  expect(mockHook).toHaveBeenCalledWith('deploy-actions', expect.objectContaining({
+    appConfig: { hooks: {} },
+    filterEntities: ['action-1', 'action-2'],
+    isLocalDev: true
+  }))
   expect(rtDeployActions).toHaveBeenCalled()
   expect(utils.runScript).toHaveBeenNthCalledWith(1, undefined) // pre-app-deploy
   expect(utils.runScript).toHaveBeenNthCalledWith(2, undefined) // deploy-actions


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

feat: Adds call to oclif hooks for `deploy-action` during run/deploy and pass… it the actions being deployed
Previous hook implementation was not fine-grained enough as when the package-script for `deploy-action` was called, there was no context of what action was being deployed and the hook-script developer had to parse the cli params themselves to see -a action-1 filters.

This hopefully allows aio-cli plugin developers a more focused hook where they implement only the required amount and not respond to every oclif hook event `init, prerun, postrun`

InProc hook is fired during the deploy-action stage of:
- `aio app deploy`
- `aio app deploy -a actionname`
- `aio app run`
- `aio app run --local`


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
