### PR TITLE
Webkit bundler

### DIFF
--- a/src/commands/app/build.js
+++ b/src/commands/app/build.js
@@ -160,6 +160,11 @@ Build.flags = {
     default: true,
     allowNo: true
   }),
+  'feature-use-webpack-for-web-assets': Flags.boolean({
+    default: false,
+    description: '(experimental) Use webpack to bundle web assets',
+    dependsOn: ['web-assets']
+  }),
   'force-build': Flags.boolean({
     description: '[default: true] Force a build even if one already exists',
     default: true,

--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -209,6 +209,11 @@ Run.flags = {
     default: true,
     allowNo: true
   }),
+  'feature-use-webpack-for-web-assets': Flags.boolean({
+    default: false,
+    description: '(experimental) Use webpack to bundle web assets',
+    dependsOn: ['web-assets']
+  }),
   actions: Flags.boolean({
     description: '[default: true] Run actions, defaults to true, to skip actions use --no-actions',
     default: true,


### PR DESCRIPTION


## Description
Experimental !!!
This uses webkit to package the frontend instead of parcel.  The details are deep in aio-lib-web, and the feature is hidden behind a flag.

There are some additional hurdles before this will be ready for primetime.
- Parcel expects an html file as the entry point, and reads the included js files linked from it.
- Webkit expects a js file entry point, and even using the html plugin there are some issues between the html file we use and what is output.  The html plugin will automatically add the js entry script tag with the generated bundle.js ( or bundle-HASH.js ) but it does not add <div id=root/> so there are template descrepencies, either there is no div, or there are 2 script tags ...

We need to test image handling, all manor of css, ... which is why this is experimental ( and hidden behind a flag. )

## Related Issue

https://github.com/adobe/aio-lib-web/pull/169

## Motivation and Context

parcel is big ... read more in the other pr

## How Has This Been Tested?

with a sample project


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
