### PR TITLE
fix: allow --no-publish with --action

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -280,7 +280,7 @@ Deploy.flags = {
   action: Flags.string({
     description: 'Deploy only a specific action, the flags can be specified multiple times, this will set --no-publish',
     char: 'a',
-    exclusive: ['extension'],
+    exclusive: ['extension', { name: 'publish', when: async (flags) => flags.publish === true }],
     multiple: true
   }),
   'web-assets': Flags.boolean({
@@ -317,8 +317,7 @@ Deploy.flags = {
   publish: Flags.boolean({
     description: '[default: true] Publish extension(s) to Exchange',
     allowNo: true,
-    default: true,
-    exclusive: ['action']
+    default: true
   }),
   'force-deploy': Flags.boolean({
     description: '[default: false] Force deploy changes, regardless of production Workspace being published in Exchange.',


### PR DESCRIPTION
## Description

Using the `--action` flag sets `--publish` to false, therefore we should allow `--no-publish` when using `--action`. 

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-app/issues/607

## Motivation and Context

Confusing flags

## How Has This Been Tested?

Locally linked app plugin and `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
