### PR TITLE
fix: output deployed action list

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -497,14 +497,11 @@ function deleteUserConfig (configData) {
 /** @private */
 const createWebExportFilter = (filterValue) => {
   return (action) => {
-    if (!action || !action.body || !action.body.annotations) {
+    if (!action || !action.annotations) {
       return false
     }
 
-    const weAnnotation = action.body.annotations.filter(a => a.key === 'web-export')
-    const weValue = (weAnnotation.length > 0) ? !!(weAnnotation[0].value) : false
-
-    return (filterValue === weValue)
+    return String(!!action.annotations['web-export']) === String(filterValue)
   }
 }
 

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -61,14 +61,7 @@ jest.mock('../../../src/lib/log-forwarding', () => {
 const LogForwarding = require('../../../src/lib/log-forwarding')
 
 const createWebExportAnnotation = (value) => ({
-  body: {
-    annotations: [
-      {
-        key: 'web-export',
-        value
-      }
-    ]
-  }
+  annotations: { 'web-export': value }
 })
 
 const createAppConfig = (aioConfig = {}, appFixtureName = 'legacy-app') => {

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -874,7 +874,7 @@ describe('createWebExportFilter', () => {
 
   test('no web-export annotation', () => {
     const action = {
-      name: 'abcde', url: 'https://fake.site', body: { annotations: [] }
+      name: 'abcde', url: 'https://fake.site', annotations: []
     }
 
     expect(webFilter(action)).toEqual(false)
@@ -885,14 +885,7 @@ describe('createWebExportFilter', () => {
     const action1 = {
       name: 'abcde',
       url: 'https://fake.site',
-      body: {
-        annotations: [
-          {
-            key: 'web-export',
-            value: true
-          }
-        ]
-      }
+      annotations: { 'web-export': true }
     }
 
     expect(webFilter(action1)).toEqual(true)
@@ -901,14 +894,7 @@ describe('createWebExportFilter', () => {
     const action2 = {
       name: 'abcde',
       url: 'https://fake.site',
-      body: {
-        annotations: [
-          {
-            key: 'web-export',
-            value: 1
-          }
-        ]
-      }
+      annotations: { 'web-export': 1 }
     }
 
     expect(webFilter(action2)).toEqual(true)
@@ -919,14 +905,7 @@ describe('createWebExportFilter', () => {
     const action1 = {
       name: 'abcde',
       url: 'https://fake.site',
-      body: {
-        annotations: [
-          {
-            key: 'web-export',
-            value: false
-          }
-        ]
-      }
+      annotations: { 'web-export': false }
     }
 
     expect(webFilter(action1)).toEqual(false)
@@ -935,14 +914,7 @@ describe('createWebExportFilter', () => {
     const action2 = {
       name: 'abcde',
       url: 'https://fake.site',
-      body: {
-        annotations: [
-          {
-            key: 'web-export',
-            value: null
-          }
-        ]
-      }
+      annotations: { 'web-export': null }
     }
 
     expect(webFilter(action2)).toEqual(false)

--- a/test/commands/lib/deploy-actions.test.js
+++ b/test/commands/lib/deploy-actions.test.js
@@ -18,14 +18,7 @@ const appHelperActual = jest.requireActual('../../../src/lib/app-helper')
 jest.mock('../../../src/lib/app-helper')
 
 const createWebExportAnnotation = (value) => ({
-  body: {
-    annotations: [
-      {
-        key: 'web-export',
-        value
-      }
-    ]
-  }
+  annotations: { 'web-export': value }
 })
 
 beforeEach(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes the missing deployed action list output, e.g.

from
```
➜  aio app deploy
✔ Deployed 2 action(s) for 'application'
no frontend, skipping frontend deploy 'application'
Your deployed actions:
[MISSING OUTPUT]
```
to

```
➜  aio app deploy
✔ Deployed 2 action(s) for 'application'
Your deployed actions:
web actions:
  -> https://<ns>.adobeioruntime.net/api/v1/web/dx-excshell-1/generic
non-web actions:
  -> dx-excshell-1/__secured_generic
```



## How Has This Been Tested?

unit tests + manual e2e testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
