### PR TITLE
removed fake file system usage, update fs-extra to v11

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,0 @@
-{
-  "typeAcquisition": {
-      "include": [
-          "jest"
-      ]
-  }
-}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dedent-js": "^1.0.1",
     "dotenv": "^16",
     "execa": "^5.0.0",
-    "fs-extra": "^10",
+    "fs-extra": "^11.1.1",
     "get-port": "^5",
     "hjson": "^3.2.1",
     "http-terminator": "^3",
@@ -61,7 +61,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "jest": "^29.5.0",
-    "jest-plugin-fs": "^2.9.0",
     "nock": "^13.2.9",
     "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.9"

--- a/test/commands/lib/log-poller.test.js
+++ b/test/commands/lib/log-poller.test.js
@@ -9,7 +9,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-global.mockFs()
 const { EventPoller, run: logPoller } = require('../../../src/lib/log-poller')
 const { printActionLogs } = require('@adobe/aio-lib-runtime')
 const mockLogger = require('@adobe/aio-lib-core-logging')

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -20,51 +20,6 @@ const eol = require('eol')
 const path = require('path')
 const hjson = require('hjson')
 
-const fileSystem = require('jest-plugin-fs').default
-
-// dont touch the real fs
-global.mockFs = () => {
-  jest.unmock('fs-extra')
-  jest.mock('fs', () => require('jest-plugin-fs/mock'))
-
-  // set the fake filesystem
-  global.fakeFileSystem = {
-    addJson: (json) => {
-      // add to existing
-      fileSystem.mock(json)
-    },
-    removeKeys: (arr) => {
-      // remove from existing
-      const files = fileSystem.files()
-      for (const prop in files) {
-        if (arr.includes(prop)) {
-          delete files[prop]
-        }
-      }
-      fileSystem.restore()
-      fileSystem.mock(files)
-    },
-    clear: () => {
-      // reset to empty
-      fileSystem.restore()
-    },
-    reset: () => {
-      // reset file system
-      // TODO: add any defaults
-      fileSystem.restore()
-    },
-    files: () => {
-      return fileSystem.files()
-    }
-  }
-  // seed the fake filesystem
-  global.fakeFileSystem.reset()
-}
-
-global.unmockFs = () => {
-
-}
-
 // trap console log
 beforeEach(() => {
   stdout.start()


### PR DESCRIPTION
Closes #631
- Removes usage of the fake filesystem in tests because of incompatibility with fs-extra@11.x (see #631)

## How Has This Been Tested?

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
