### PR TITLE
fix: aio app pack, aio app install output cleanup, fixes

### DIFF
--- a/src/commands/app/install.js
+++ b/src/commands/app/install.js
@@ -48,11 +48,12 @@ class InstallCommand extends BaseCommand {
       await this.unzipFile(args.path, outputPath)
       await this.validateConfig(outputPath, USER_CONFIG_FILE)
       await this.validateConfig(outputPath, DEPLOY_CONFIG_FILE)
-      await this.runTests(flags.verbose)
+      await this.npmInstall(flags.verbose)
+      await this.runTests()
       this.spinner.succeed('Install done.')
     } catch (e) {
       this.spinner.fail(e.message)
-      this.error(e.message)
+      this.error(flags.verbose ? e : e.message)
     }
   }
 
@@ -128,7 +129,6 @@ class InstallCommand extends BaseCommand {
   }
 
   async runTests (isVerbose) {
-    await this.npmInstall(isVerbose)
     this.spinner.start('Running app tests...')
     return this.config.runCommand('app:test').then((result) => {
       if (result === 0) { // success

--- a/src/commands/app/install.js
+++ b/src/commands/app/install.js
@@ -15,10 +15,12 @@ const { Flags } = require('@oclif/core')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-app:install', { provider: 'debug' })
 const path = require('node:path')
 const fs = require('fs-extra')
+const execa = require('execa')
 const unzipper = require('unzipper')
 const { validateJsonWithSchema } = require('../../lib/install-helper')
 const jsYaml = require('js-yaml')
 const { USER_CONFIG_FILE, DEPLOY_CONFIG_FILE } = require('../../lib/defaults')
+const ora = require('ora')
 
 class InstallCommand extends BaseCommand {
   async run () {
@@ -41,13 +43,24 @@ class InstallCommand extends BaseCommand {
       aioLogger.debug(`changed current working directory to: ${outputPath}`)
     }
 
-    await this.validateZipDirectoryStructure(args.path)
-    await this.unzipFile(args.path, outputPath)
-    await this.validateConfig(outputPath, USER_CONFIG_FILE)
-    await this.validateConfig(outputPath, DEPLOY_CONFIG_FILE)
-    await this.runTests()
+    try {
+      await this.validateZipDirectoryStructure(args.path)
+      await this.unzipFile(args.path, outputPath)
+      await this.validateConfig(outputPath, USER_CONFIG_FILE)
+      await this.validateConfig(outputPath, DEPLOY_CONFIG_FILE)
+      await this.runTests(flags.verbose)
+      this.spinner.succeed('Install done.')
+    } catch (e) {
+      this.spinner.fail(e.message)
+      this.error(e.message)
+    }
+  }
 
-    this.log('Install done.')
+  get spinner () {
+    if (!this._spinner) {
+      this._spinner = ora()
+    }
+    return this._spinner
   }
 
   diffArray (expected, actual) {
@@ -62,7 +75,7 @@ class InstallCommand extends BaseCommand {
     const expectedFiles = [USER_CONFIG_FILE, DEPLOY_CONFIG_FILE, 'package.json']
     const foundFiles = []
 
-    this.log(`Validating integrity of app package at ${zipFilePath}...`)
+    this.spinner.start(`Validating integrity of app package at ${zipFilePath}...`)
 
     const zip = fs.createReadStream(zipFilePath).pipe(unzipper.Parse({ forceStream: true }))
     for await (const entry of zip) {
@@ -76,33 +89,54 @@ class InstallCommand extends BaseCommand {
 
     const diff = this.diffArray(expectedFiles, foundFiles)
     if (diff.length > 0) {
-      this.error(`The app package ${zipFilePath} is missing these files: ${JSON.stringify(diff, null, 2)}`)
+      throw new Error(`The app package ${zipFilePath} is missing these files: ${JSON.stringify(diff, null, 2)}`)
     }
+    this.spinner.succeed(`Validated integrity of app package at ${zipFilePath}`)
   }
 
   async unzipFile (zipFilePath, destFolderPath) {
     aioLogger.debug(`unzipFile: ${zipFilePath} to be extracted to ${destFolderPath}`)
 
-    this.log(`Extracting app package to ${destFolderPath}...`)
+    this.spinner.start(`Extracting app package to ${destFolderPath}...`)
     return unzipper.Open.file(zipFilePath)
-      .then(d => d.extract({ path: destFolderPath, concurrency: 5 }))
+      .then((d) => {
+        d.extract({ path: destFolderPath, concurrency: 5 })
+        this.spinner.succeed(`Extracted app package to ${destFolderPath}`)
+      })
   }
 
   async validateConfig (outputPath, configFileName, configFilePath = path.join(outputPath, configFileName)) {
-    this.log(`Validating ${configFileName}...`)
+    this.spinner.start(`Validating ${configFileName}...`)
     aioLogger.debug(`validateConfig: ${configFileName} at ${configFilePath}`)
 
     const configFileJson = jsYaml.load(fs.readFileSync(configFilePath).toString())
     const { valid, errors } = validateJsonWithSchema(configFileJson, configFileName)
     if (!valid) {
-      const message = `Missing or invalid keys in ${configFileName}: ${JSON.stringify(errors, null, 2)}`
-      this.error(message)
+      throw new Error(`Missing or invalid keys in ${configFileName}: ${JSON.stringify(errors, null, 2)}`)
+    } else {
+      this.spinner.succeed(`Validated ${configFileName}`)
     }
   }
 
-  async runTests () {
-    this.log('Running tests...')
-    return this.config.runCommand('app:test')
+  async npmInstall (isVerbose) {
+    this.spinner.start('Running npm install...')
+    const stdio = isVerbose ? 'inherit' : 'ignore'
+    return execa('npm', ['install'], { stdio })
+      .then(() => {
+        this.spinner.succeed('Ran npm install')
+      })
+  }
+
+  async runTests (isVerbose) {
+    await this.npmInstall(isVerbose)
+    this.spinner.start('Running app tests...')
+    return this.config.runCommand('app:test').then((result) => {
+      if (result === 0) { // success
+        this.spinner.succeed('App tests passed')
+      } else {
+        throw new Error('App tests failed')
+      }
+    })
   }
 }
 

--- a/src/commands/app/test.js
+++ b/src/commands/app/test.js
@@ -48,6 +48,7 @@ class Test extends BaseCommand {
 
     this.printReport(totalResults)
     process.exitCode = exitCode
+    return exitCode
   }
 
   printReport (totalResults) {

--- a/test/commands/app/install.test.js
+++ b/test/commands/app/install.test.js
@@ -287,15 +287,46 @@ describe('run', () => {
     command.unzipFile = jest.fn()
     command.validateConfig = jest.fn()
     command.runTests = jest.fn()
+    command.npmInstall = jest.fn()
+    command.error = jest.fn()
     await command.run()
 
     expect(command.validateZipDirectoryStructure).toHaveBeenCalledTimes(1)
     expect(command.unzipFile).toHaveBeenCalledTimes(1)
     expect(command.validateConfig).toHaveBeenCalledTimes(2)
     expect(command.runTests).toHaveBeenCalledTimes(1)
+    expect(command.npmInstall).toHaveBeenCalledTimes(1)
+    expect(command.error).toHaveBeenCalledTimes(0)
   })
 
-  test('subcommand throws error', async () => {
+  test('subcommand throws error (--verbose)', async () => {
+    const command = new TheCommand()
+    command.argv = ['my-app.zip', '--verbose']
+
+    const errorObject = new Error('this is a subcommand error message')
+
+    // since we already unit test the methods above, we mock it here
+    // we only reject one call, to simulate a subcommand failure
+    command.validateZipDirectoryStructure = jest.fn()
+    command.unzipFile = jest.fn()
+    command.validateConfig = jest.fn()
+    command.npmInstall = jest.fn()
+    command.error = jest.fn()
+    command.runTests = jest.fn(() => { throw errorObject })
+
+    await command.run()
+
+    expect(command.validateZipDirectoryStructure).toHaveBeenCalledTimes(1)
+    expect(command.unzipFile).toHaveBeenCalledTimes(1)
+    expect(command.validateConfig).toHaveBeenCalledTimes(2)
+    expect(command.runTests).toHaveBeenCalledTimes(1)
+    expect(command.npmInstall).toHaveBeenCalledTimes(1)
+    expect(command.error).toHaveBeenCalledTimes(1)
+
+    expect(command.error).toHaveBeenCalledWith(errorObject)
+  })
+
+  test('subcommand throws error (not verbose)', async () => {
     const command = new TheCommand()
     command.argv = ['my-app.zip']
 
@@ -306,16 +337,20 @@ describe('run', () => {
     command.validateZipDirectoryStructure = jest.fn()
     command.unzipFile = jest.fn()
     command.validateConfig = jest.fn()
-    command.runTests = jest.fn(() => {
-      throw new Error(errorMessage)
-    })
+    command.npmInstall = jest.fn()
+    command.error = jest.fn()
+    command.runTests = jest.fn(() => { throw new Error(errorMessage) })
 
-    await expect(command.run()).rejects.toThrow(errorMessage)
+    await command.run()
 
     expect(command.validateZipDirectoryStructure).toHaveBeenCalledTimes(1)
     expect(command.unzipFile).toHaveBeenCalledTimes(1)
     expect(command.validateConfig).toHaveBeenCalledTimes(2)
     expect(command.runTests).toHaveBeenCalledTimes(1)
+    expect(command.npmInstall).toHaveBeenCalledTimes(1)
+    expect(command.error).toHaveBeenCalledTimes(1)
+
+    expect(command.error).toHaveBeenCalledWith(errorMessage)
   })
 
   test('flag --output', async () => {
@@ -327,12 +362,17 @@ describe('run', () => {
     command.unzipFile = jest.fn()
     command.validateConfig = jest.fn()
     command.runTests = jest.fn()
+    command.npmInstall = jest.fn()
+    command.error = jest.fn()
+
     await command.run()
 
     expect(command.validateZipDirectoryStructure).toHaveBeenCalledTimes(1)
     expect(command.unzipFile).toHaveBeenCalledTimes(1)
     expect(command.validateConfig).toHaveBeenCalledTimes(2)
     expect(command.runTests).toHaveBeenCalledTimes(1)
+    expect(command.npmInstall).toHaveBeenCalledTimes(1)
+    expect(command.error).toHaveBeenCalledTimes(0)
     expect(fakeCwd).toEqual(path.resolve('my-dest-folder'))
   })
 })


### PR DESCRIPTION
- add `npm install` step to `aio app install` (if not `aio app test` will fail)
- `aio app pack` will not include the output zip (if it exists in the project)
- cleaned up info output by using ora spinner
- updated tests and coverage

## How Has This Been Tested?

- npm test
- manual tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
