### PR TITLE
Improve message to users around template selection

### DIFF
--- a/src/TemplatesCommand.js
+++ b/src/TemplatesCommand.js
@@ -113,7 +113,7 @@ class TemplatesCommand extends AddCommand {
           type: 'table',
           name: promptName,
           bottomContent: `* = recommended by Adobe; to learn more about the templates, go to ${hyperlinker('https://adobe.ly/templates', 'https://adobe.ly/templates')}`,
-          message: 'Choose the template(s) to install:\nPressing <enter> without selection will skip templates and install a standalone application.',
+          message: 'Choose the template(s) to install:\n  Pressing <enter> without selection will skip templates and install a standalone application.\n',
           style: { head: [], border: [] },
           wordWrap: true,
           wrapOnWordBoundary: false,

--- a/src/TemplatesCommand.js
+++ b/src/TemplatesCommand.js
@@ -113,7 +113,7 @@ class TemplatesCommand extends AddCommand {
           type: 'table',
           name: promptName,
           bottomContent: `* = recommended by Adobe; to learn more about the templates, go to ${hyperlinker('https://adobe.ly/templates', 'https://adobe.ly/templates')}`,
-          message: 'Choose the template(s) to install:',
+          message: 'Choose the template(s) to install: /n (use spacebar to select, up/down to navigate, enter to confirm) /n No selection will create a deafult standalone app',
           style: { head: [], border: [] },
           wordWrap: true,
           wrapOnWordBoundary: false,

--- a/src/TemplatesCommand.js
+++ b/src/TemplatesCommand.js
@@ -113,7 +113,7 @@ class TemplatesCommand extends AddCommand {
           type: 'table',
           name: promptName,
           bottomContent: `* = recommended by Adobe; to learn more about the templates, go to ${hyperlinker('https://adobe.ly/templates', 'https://adobe.ly/templates')}`,
-          message: 'Choose the template(s) to install: /n (use spacebar to select, up/down to navigate, enter to confirm) /n No selection will create a deafult standalone app',
+          message: 'Choose the template(s) to install:\nPressing <enter> without selection will skip templates and install a stand-alone application.', 
           style: { head: [], border: [] },
           wordWrap: true,
           wrapOnWordBoundary: false,

--- a/src/TemplatesCommand.js
+++ b/src/TemplatesCommand.js
@@ -113,7 +113,7 @@ class TemplatesCommand extends AddCommand {
           type: 'table',
           name: promptName,
           bottomContent: `* = recommended by Adobe; to learn more about the templates, go to ${hyperlinker('https://adobe.ly/templates', 'https://adobe.ly/templates')}`,
-          message: 'Choose the template(s) to install:\nPressing <enter> without selection will skip templates and install a stand-alone application.', 
+          message: 'Choose the template(s) to install:\nPressing <enter> without selection will skip templates and install a standalone application.',
           style: { head: [], border: [] },
           wordWrap: true,
           wrapOnWordBoundary: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Making it more clear that users can skip template selection during `aio app init`

<!--- Describe your changes in detail -->

https://github.com/adobe/aio-cli-plugin-app/issues/683

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Users are asking for help at this step in slack

## How Has This Been Tested?

tested plugin locally with and without template selection

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
