### PR TITLE
pre/post-deploy-event-reg receives force boolean --force-events

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -146,7 +146,7 @@ class Deploy extends BuildCommand {
 
       if (flags['feature-event-hooks']) {
         this.log('feature-event-hooks is enabled, running pre-deploy-event-reg hook')
-        const hookResults = await this.config.runHook('pre-deploy-event-reg', { appConfig: config })
+        const hookResults = await this.config.runHook('pre-deploy-event-reg', { appConfig: config, force: flags['force-events'] })
         if (hookResults?.failures?.length > 0) {
           // output should be "Error : <plugin-name> : <error-message>\n" for each failure
           this.error(hookResults.failures.map(f => `${f.plugin.name} : ${f.error.message}`).join('\nError: '), { exit: 1 })
@@ -254,7 +254,7 @@ class Deploy extends BuildCommand {
       await runScript(config.hooks['post-app-deploy'])
       if (flags['feature-event-hooks']) {
         this.log('feature-event-hooks is enabled, running post-deploy-event-reg hook')
-        const hookResults = await this.config.runHook('post-deploy-event-reg', { appConfig: config })
+        const hookResults = await this.config.runHook('post-deploy-event-reg', { appConfig: config, force: flags['force-events'] })
         if (hookResults?.failures?.length > 0) {
           // output should be "Error : <plugin-name> : <error-message>\n" for each failure
           this.error(hookResults.failures.map(f => `${f.plugin.name} : ${f.error.message}`).join('\nError: '), { exit: 1 })
@@ -352,6 +352,13 @@ Deploy.flags = {
   'force-publish': Flags.boolean({
     description: '[default: false] Force publish extension(s) to Exchange, delete previously published extension points',
     default: false,
+    exclusive: ['action', 'publish'] // no-publish is excluded
+  }),
+  'force-events': Flags.boolean({
+    description: '[default: false] Force event registrations and overwrite any previous registrations',
+    default: false,
+    allowNo: true,
+    dependsOn: ['feature-event-hooks'],
     exclusive: ['action', 'publish'] // no-publish is excluded
   }),
   'web-optimize': Flags.boolean({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Flag is passed to pre-deploy-event-reg and post-deploy-event-reg hooks to indicate if remote event registrations should be deleted if they are not present in appConfig

## Related Issue

ACNA-1998

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
