### PR TITLE
fix: handle mesh config 404 error

### DIFF
--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -135,13 +135,23 @@ class Pack extends BaseCommand {
     // TODO: send a PR to their plugin to have a `--json` flag
     const command = await this.config.findCommand('api-mesh:get')
     if (command) {
-      this.spinner.start('Getting api-mesh config...')
-      const { stdout } = await execa('aio', ['api-mesh', 'get'], { cwd: process.cwd() })
-      // until we get the --json flag, we parse the output
-      const idx = stdout.indexOf('{')
-      meshConfig = JSON.parse(stdout.substring(idx))
-      aioLogger.debug(`api-mesh:get - ${JSON.stringify(meshConfig, null, 2)}`)
-      this.spinner.succeed('Got api-mesh config')
+      try {
+        this.spinner.start('Getting api-mesh config...')
+        const { stdout } = await execa('aio', ['api-mesh', 'get'], { cwd: process.cwd() })
+        // until we get the --json flag, we parse the output
+        const idx = stdout.indexOf('{')
+        meshConfig = JSON.parse(stdout.substring(idx))
+        aioLogger.debug(`api-mesh:get - ${JSON.stringify(meshConfig, null, 2)}`)
+        this.spinner.succeed('Got api-mesh config')
+      } catch (err) {
+        // Ignore error if no mesh found, otherwise throw
+        if (err?.stderr.includes('Error: Unable to get mesh config. No mesh found for Org')) {
+          aioLogger.debug('No api-mesh config found')
+        } else {
+          console.error(err)
+          throw err
+        }
+      }
     } else {
       aioLogger.debug('api-mesh:get command was not found, meshConfig is not available for app:pack')
     }


### PR DESCRIPTION
## Description

If the user has the api-mesh plugin installed and runs `aio app pack` on a project without an api-mesh config, packing will fail with a not found error. This PR proposes ignoring these errors and continuing to pack

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-app/issues/699

## Motivation and Context

So `aio app pack` works with all plugins installed

## How Has This Been Tested?

Locally linked plugin, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
