### PR TITLE
feat: add disable code download annotation during install

### DIFF
--- a/src/commands/app/install.js
+++ b/src/commands/app/install.js
@@ -18,6 +18,8 @@ const fs = require('fs-extra')
 const execa = require('execa')
 const unzipper = require('unzipper')
 const { validateJsonWithSchema } = require('../../lib/install-helper')
+const { loadConfigFile, writeFile } = require('../../lib/import-helper')
+const { getObjectValue } = require('../../lib/app-helper')
 const jsYaml = require('js-yaml')
 const { USER_CONFIG_FILE, DEPLOY_CONFIG_FILE } = require('../../lib/defaults')
 const ora = require('ora')
@@ -28,6 +30,7 @@ class InstallCommand extends BaseCommand {
     const { args, flags } = await this.parse(InstallCommand)
 
     this.preRelease()
+    const appConfig = this.getFullConfig()
 
     aioLogger.debug(`flags: ${JSON.stringify(flags, null, 2)}`)
     aioLogger.debug(`args: ${JSON.stringify(args, null, 2)}`)
@@ -49,6 +52,7 @@ class InstallCommand extends BaseCommand {
     try {
       await this.validateZipDirectoryStructure(args.path)
       await this.unzipFile(args.path, outputPath)
+      await this.addCodeDownloadAnnotation(outputPath, appConfig)
       await this.validateConfig(outputPath, USER_CONFIG_FILE)
       await this.validateConfig(outputPath, DEPLOY_CONFIG_FILE)
       await this.npmInstall(flags.verbose)
@@ -138,6 +142,67 @@ class InstallCommand extends BaseCommand {
         throw new Error('App tests failed')
       }
     })
+  }
+
+  /**
+   * An annotation called code-download will be added to all actions in app.config.yaml
+   * (and linked yaml configs for example in extensions). This value will be set to false.
+   * The annotation will by default be true if not set.
+   *
+   * @param {object} outputPath the path to the app package
+   * @param {object} appConfig the app's configuration file
+   */
+  async addCodeDownloadAnnotation (outputPath, appConfig) {
+    this.spinner.start('Adding code-download annotations...')
+    // get each annotation key relative to the file it is defined in
+    /// iterate only over extensions that have actions defined
+    const fileToAnnotationKey = {}
+    Object.entries(appConfig.all)
+      .filter(([_, extConf]) => extConf.manifest?.full?.packages)
+      .forEach(([ext, extConf]) => {
+        Object.entries(extConf.manifest.full.packages)
+          .filter(([pkg, pkgConf]) => pkgConf.actions)
+          .forEach(([pkg, pkgConf]) => {
+            Object.entries(pkgConf.actions).forEach(([action, actionConf]) => {
+              const baseFullKey = ext === 'application'
+                ? `application.runtimeManifest.packages.${pkg}.actions.${action}`
+                : `extensions.${ext}.runtimeManifest.packages.${pkg}.actions.${action}`
+
+              let index
+              if (actionConf.annotations) {
+                index = appConfig.includeIndex[`${baseFullKey}.annotations`]
+              } else {
+                // the annotation object is not defined, take the parent key
+                index = appConfig.includeIndex[baseFullKey]
+              }
+              if (!fileToAnnotationKey[index.file]) {
+                fileToAnnotationKey[index.file] = []
+              }
+              fileToAnnotationKey[index.file].push(index.key) // index.key is relative to the file
+            })
+          })
+      })
+
+    // rewrite config files
+    for (const [file, keys] of Object.entries(fileToAnnotationKey)) {
+      const configFilePath = path.join(outputPath, file)
+      const { values } = loadConfigFile(configFilePath)
+
+      keys.forEach(key => {
+        const object = getObjectValue(values, key)
+        if (key.endsWith('.annotations') || key === 'annotations') {
+          // object is the annotations object
+          object['code-download'] = false
+        } else {
+          // annotation object is not defined, the object is the action object
+          object.annotations = { 'code-download': false }
+        }
+      })
+
+      // write back the modified manifest to disk
+      await writeFile(configFilePath, jsYaml.dump(values), { overwrite: true })
+    }
+    this.spinner.succeed('Added code-download annotations')
   }
 }
 

--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -17,8 +17,7 @@ const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-
 const archiver = require('archiver')
 const yaml = require('js-yaml')
 const execa = require('execa')
-const { loadConfigFile, writeFile } = require('../../lib/import-helper')
-const { getObjectValue } = require('../../lib/app-helper')
+const { writeFile } = require('../../lib/import-helper')
 const ora = require('ora')
 const chalk = require('chalk')
 
@@ -69,10 +68,6 @@ class Pack extends BaseCommand {
       this.spinner.start('Creating configuration files...')
       await this.createDeployYamlFile(appConfig)
       this.spinner.succeed('Created configuration files')
-
-      this.spinner.start('Adding code-download annotations...')
-      await this.addCodeDownloadAnnotation(appConfig)
-      this.spinner.succeed('Added code-download annotations')
 
       // doing this before zip so other things can be added to the zip
       await this.config.runHook('post-pack', { appConfig, artifactsFolder: DEFAULTS.ARTIFACTS_FOLDER })
@@ -242,64 +237,6 @@ class Pack extends BaseCommand {
     return files
       .map(file => file.path)
       .filter(file => !filesToExclude.includes(file))
-  }
-
-  /**
-   * An annotation called code-download will be added to all actions in app.config.yaml
-   * (and linked yaml configs for example in extensions). This value will be set to false.
-   * The annotation will by default be true if not set.
-   *
-   * @param {object} appConfig the app's configuration file
-   */
-  async addCodeDownloadAnnotation (appConfig) {
-    // get each annotation key relative to the file it is defined in
-    /// iterate only over extensions that have actions defined
-    const fileToAnnotationKey = {}
-    Object.entries(appConfig.all)
-      .filter(([_, extConf]) => extConf.manifest?.full?.packages)
-      .forEach(([ext, extConf]) => {
-        Object.entries(extConf.manifest.full.packages)
-          .filter(([pkg, pkgConf]) => pkgConf.actions)
-          .forEach(([pkg, pkgConf]) => {
-            Object.entries(pkgConf.actions).forEach(([action, actionConf]) => {
-              const baseFullKey = ext === 'application'
-                ? `application.runtimeManifest.packages.${pkg}.actions.${action}`
-                : `extensions.${ext}.runtimeManifest.packages.${pkg}.actions.${action}`
-
-              let index
-              if (actionConf.annotations) {
-                index = appConfig.includeIndex[`${baseFullKey}.annotations`]
-              } else {
-                // the annotation object is not defined, take the parent key
-                index = appConfig.includeIndex[baseFullKey]
-              }
-              if (!fileToAnnotationKey[index.file]) {
-                fileToAnnotationKey[index.file] = []
-              }
-              fileToAnnotationKey[index.file].push(index.key) // index.key is relative to the file
-            })
-          })
-      })
-
-    // rewrite config files
-    for (const [file, keys] of Object.entries(fileToAnnotationKey)) {
-      const configFilePath = path.join(DEFAULTS.ARTIFACTS_FOLDER, file)
-      const { values } = loadConfigFile(configFilePath)
-
-      keys.forEach(key => {
-        const object = getObjectValue(values, key)
-        if (key.endsWith('.annotations') || key === 'annotations') {
-          // object is the annotations object
-          object['code-download'] = false
-        } else {
-          // annotation object is not defined, the object is the action object
-          object.annotations = { 'code-download': false }
-        }
-      })
-
-      // write back the modified manifest to disk
-      await writeFile(configFilePath, yaml.dump(values), { overwrite: true })
-    }
   }
 }
 

--- a/test/__fixtures__/install/1.all.config.json
+++ b/test/__fixtures__/install/1.all.config.json
@@ -1,0 +1,145 @@
+{
+  "all": {
+    "dx/excshell/1": {
+      "app": {
+        "hasBackend": true,
+        "hasFrontend": true,
+        "dist": "dist\\dx-excshell-1",
+        "defaultHostname": "adobeio-static.net",
+        "hostname": "adobeio-static.net",
+        "htmlCacheDuration": "60",
+        "jsCacheDuration": "604800",
+        "cssCacheDuration": "604800",
+        "imageCacheDuration": "604800",
+        "name": "my-app",
+        "version": "0.0.1"
+      },
+      "manifest": {
+        "src": "manifest.yml",
+        "full": {
+          "packages": {
+            "dx-excshell-1": {
+              "license": "Apache-2.0",
+              "actions": {
+                "generic": {
+                  "function": "src\\dx-excshell-1\\actions\\generic\\index.js",
+                  "web": "yes",
+                  "runtime": "nodejs:16",
+                  "inputs": {
+                    "LOG_LEVEL": "debug"
+                  },
+                  "annotations": {
+                    "require-adobe-auth": true,
+                    "final": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "packagePlaceholder": "__APP_PACKAGE__"
+      }
+    }
+  },
+  "implements": [
+    "dx/excshell/1"
+  ],
+  "includeIndex": {
+    "extensions": {
+      "file": "app.config.yaml",
+      "key": "extensions"
+    },
+    "extensions.dx/excshell/1": {
+      "file": "app.config.yaml",
+      "key": "extensions.dx/excshell/1"
+    },
+    "extensions.dx/excshell/1.$include": {
+      "file": "app.config.yaml",
+      "key": "extensions.dx/excshell/1.$include"
+    },
+    "extensions.dx/excshell/1.runtimeManifest": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.annotations": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.annotations"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.annotations.final": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.annotations.final"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.annotations.require-adobe-auth": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.annotations.require-adobe-auth"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.inputs": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.inputs"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.inputs.LOG_LEVEL": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.inputs.LOG_LEVEL"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.runtime": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.runtime"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.web": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.web"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.function": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic.function"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.license": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.license"
+    },
+    "extensions.dx/excshell/1.web": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "web"
+    },
+    "extensions.dx/excshell/1.actions": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "actions"
+    },
+    "extensions.dx/excshell/1.operations": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations"
+    },
+    "extensions.dx/excshell/1.operations.view": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view"
+    },
+    "extensions.dx/excshell/1.operations.view.0": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view.0"
+    },
+    "extensions.dx/excshell/1.operations.view.0.impl": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view.0.impl"
+    },
+    "extensions.dx/excshell/1.operations.view.0.type": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view.0.type"
+    }
+  }
+}

--- a/test/__fixtures__/install/1.annotation-added.config.json
+++ b/test/__fixtures__/install/1.annotation-added.config.json
@@ -1,0 +1,34 @@
+{
+  "operations": {
+    "view": [
+      {
+        "type": "web",
+        "impl": "index.html"
+      }
+    ]
+  },
+  "actions": "actions",
+  "web": "web-src",
+  "runtimeManifest": {
+    "packages": {
+      "dx-excshell-1": {
+        "license": "Apache-2.0",
+        "actions": {
+          "generic": {
+            "function": "actions/generic/index.js",
+            "web": "yes",
+            "runtime": "nodejs:16",
+            "inputs": {
+              "LOG_LEVEL": "debug"
+            },
+            "annotations": {
+              "require-adobe-auth": true,
+              "final": true,
+              "code-download": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/__fixtures__/install/1.ext.config-loaded.json
+++ b/test/__fixtures__/install/1.ext.config-loaded.json
@@ -1,0 +1,35 @@
+{
+  "values": {
+    "operations": {
+      "view": [
+        {
+          "type": "web",
+          "impl": "index.html"
+        }
+      ]
+    },
+    "actions": "actions",
+    "web": "web-src",
+    "runtimeManifest": {
+      "packages": {
+        "dx-excshell-1": {
+          "license": "Apache-2.0",
+          "actions": {
+            "generic": {
+              "function": "actions/generic/index.js",
+              "web": "yes",
+              "runtime": "nodejs:16",
+              "inputs": {
+                "LOG_LEVEL": "debug"
+              },
+              "annotations": {
+                "require-adobe-auth": true,
+                "final": true
+              }
+            }
+          }
+        }
+      }
+    }  
+  }
+}

--- a/test/__fixtures__/install/5.all.config.json
+++ b/test/__fixtures__/install/5.all.config.json
@@ -1,0 +1,247 @@
+{
+  "all": {
+    "application": {
+      "manifest": {
+        "src": "manifest.yml",
+        "full": {
+          "packages": {
+            "emptypackage": {},
+            "mypackage": {
+              "actions": {
+                "generic3": {
+                  "function": "src\\dx-excshell-1\\actions\\generic\\index.js",
+                  "runtime": "nodejs:16"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "empty/extension": {},
+    "dx/excshell/1": {
+      "app": {
+        "hasBackend": true,
+        "hasFrontend": true,
+        "dist": "dist\\dx-excshell-1",
+        "defaultHostname": "adobeio-static.net",
+        "hostname": "adobeio-static.net",
+        "htmlCacheDuration": "60",
+        "jsCacheDuration": "604800",
+        "cssCacheDuration": "604800",
+        "imageCacheDuration": "604800",
+        "name": "my-app",
+        "version": "0.0.1"
+      },
+      "manifest": {
+        "src": "manifest.yml",
+        "full": {
+          "packages": {
+            "dx-excshell-1": {
+              "license": "Apache-2.0",
+              "actions": {
+                "generic": {
+                  "function": "src\\dx-excshell-1\\actions\\generic\\index.js",
+                  "web": "yes",
+                  "runtime": "nodejs:16",
+                  "inputs": {
+                    "LOG_LEVEL": "debug"
+                  },
+                  "annotations": {
+                    "require-adobe-auth": true,
+                    "final": true
+                  }
+                },
+                "generic2": {
+                  "function": "src\\dx-excshell-1\\actions\\generic\\index.js",
+                  "runtime": "nodejs:16",
+                  "annotations": {}
+                },
+                "generic4": {
+                  "function": "src\\dx-excshell-1\\actions\\generic\\index.js",
+                  "runtime": "nodejs:16",
+                  "annotations": {}
+                }
+              }
+            }
+          }
+        },
+        "packagePlaceholder": "__APP_PACKAGE__"
+      }
+    }
+  },
+  "implements": [
+    "application",
+    "dx/excshell/1"
+  ],
+  "includeIndex": {
+    "application": {
+      "file": "app.config.yaml",
+      "key": "application"
+    },
+    "application.runtimeManifest": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest"
+    },
+    "application.runtimeManifest.packages": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages"
+    },
+    "application.runtimeManifest.packages.mypackage": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages.mypackage"
+    },
+    "application.runtimeManifest.packages.emptypackage": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages.emptypackage"
+    },
+    "application.runtimeManifest.packages.mypackage.actions": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages.mypackage.actions"
+    },
+    "application.runtimeManifest.packages.mypackage.actions.generic3": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages.mypackage.actions.generic3"
+    },
+    "application.runtimeManifest.packages.mypackage.actions.generic3.function": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages.mypackage.actions.generic3.function"
+    },
+    "application.runtimeManifest.packages.mypackage.actions.generic3.runtime": {
+      "file": "app.config.yaml",
+      "key": "application.runtimeManifest.packages.mypackage.actions.generic3.runtime"
+    },
+    "extensions": {
+      "file": "app.config.yaml",
+      "key": "extensions"
+    },
+    "extensions.empty/extension": {
+      "file": "app.config.yaml",
+      "key": "extensions.empty/extension"
+    },
+    "extensions.dx/excshell/1": {
+      "file": "app.config.yaml",
+      "key": "extensions.dx/excshell/1"
+    },
+    "extensions.dx/excshell/1.$include": {
+      "file": "app.config.yaml",
+      "key": "extensions.dx/excshell/1.$include"
+    },
+    "extensions.dx/excshell/1.runtimeManifest": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic2": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic2"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic2.runtime": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic2.runtime"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic2.function": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.actions.generic2.function"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic2.annotations": {
+      "file": "src/sub2.config.yaml",
+      "key": "annotations"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic": {
+      "file": "sub1.config.yaml",
+      "key": "generic"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.annotations": {
+      "file": "sub1.config.yaml",
+      "key": "generic.annotations"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.annotations.final": {
+      "file": "sub1.config.yaml",
+      "key": "generic.annotations.final"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.annotations.require-adobe-auth": {
+      "file": "sub1.config.yaml",
+      "key": "generic.annotations.require-adobe-auth"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.inputs": {
+      "file": "sub1.config.yaml",
+      "key": "generic.inputs"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.inputs.LOG_LEVEL": {
+      "file": "sub1.config.yaml",
+      "key": "generic.inputs.LOG_LEVEL"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.runtime": {
+      "file": "sub1.config.yaml",
+      "key": "generic.runtime"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.web": {
+      "file": "sub1.config.yaml",
+      "key": "generic.web"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic.function": {
+      "file": "sub1.config.yaml",
+      "key": "generic.function"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic4": {
+      "file": "sub1.config.yaml",
+      "key": "generic4"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic4.function": {
+      "file": "sub1.config.yaml",
+      "key": "generic4.function"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic4.runtime": {
+      "file": "sub1.config.yaml",
+      "key": "generic4.runtime"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.actions.generic4.annotations": {
+      "file": "sub1.config.yaml",
+      "key": "generic4.annotations"
+    },
+    "extensions.dx/excshell/1.runtimeManifest.packages.dx-excshell-1.license": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "runtimeManifest.packages.dx-excshell-1.license"
+    },
+    "extensions.dx/excshell/1.web": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "web"
+    },
+    "extensions.dx/excshell/1.actions": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "actions"
+    },
+    "extensions.dx/excshell/1.operations": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations"
+    },
+    "extensions.dx/excshell/1.operations.view": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view"
+    },
+    "extensions.dx/excshell/1.operations.view.0": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view.0"
+    },
+    "extensions.dx/excshell/1.operations.view.0.impl": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view.0.impl"
+    },
+    "extensions.dx/excshell/1.operations.view.0.type": {
+      "file": "src/dx-excshell-1/ext.config.yaml",
+      "key": "operations.view.0.type"
+    }
+  }
+}

--- a/test/__fixtures__/install/5.app.annotation-added.config.json
+++ b/test/__fixtures__/install/5.app.annotation-added.config.json
@@ -1,0 +1,19 @@
+{
+  "application": {
+    "runtimeManifest": {
+      "packages": {
+        "mypackage": {
+          "actions": {
+            "generic3": {
+              "function": "actions/generic/index.js",
+              "runtime": "nodejs:16",
+              "annotations": {
+                "code-download": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/__fixtures__/install/5.app.config-loaded.json
+++ b/test/__fixtures__/install/5.app.config-loaded.json
@@ -1,0 +1,18 @@
+{
+  "values": {
+    "application": {
+      "runtimeManifest": {
+        "packages": {
+          "mypackage": {
+            "actions": {
+              "generic3": {
+                "function": "actions/generic/index.js",
+                "runtime": "nodejs:16"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/__fixtures__/install/5.sub1.annotation-added.config.json
+++ b/test/__fixtures__/install/5.sub1.annotation-added.config.json
@@ -1,0 +1,22 @@
+{
+  "generic": {
+    "function": "actions/generic/index.js",
+    "web": "yes",
+    "runtime": "nodejs:16",
+    "inputs": {
+      "LOG_LEVEL": "debug"
+    },
+    "annotations": {
+      "require-adobe-auth": true,
+      "final": true,
+      "code-download": false
+    }
+  },
+  "generic4": {
+    "function": "actions/generic/index.js",
+    "runtime": "nodejs:16",
+    "annotations": {
+      "code-download": false
+    }
+  }
+}

--- a/test/__fixtures__/install/5.sub1.config-loaded.json
+++ b/test/__fixtures__/install/5.sub1.config-loaded.json
@@ -1,0 +1,21 @@
+{
+  "values": {
+    "generic": {
+      "function": "actions/generic/index.js",
+      "web": "yes",
+      "runtime": "nodejs:16",
+      "inputs": {
+        "LOG_LEVEL": "debug"
+      },
+      "annotations": {
+        "require-adobe-auth": true,
+        "final": true
+      }
+    },
+    "generic4": {
+      "function": "actions/generic/index.js",
+      "runtime": "nodejs:16",
+      "annotations": {}
+    }
+  }
+}

--- a/test/__fixtures__/install/5.sub2.annotation-added.config.json
+++ b/test/__fixtures__/install/5.sub2.annotation-added.config.json
@@ -1,0 +1,5 @@
+{
+  "annotations": {
+    "code-download": false
+  }
+}

--- a/test/__fixtures__/install/5.sub2.config-loaded.json
+++ b/test/__fixtures__/install/5.sub2.config-loaded.json
@@ -1,0 +1,3 @@
+{
+  "values": { "annotations": {} }
+}

--- a/test/commands/app/install.test.js
+++ b/test/commands/app/install.test.js
@@ -16,6 +16,7 @@ const fs = require('fs-extra')
 const unzipper = require('unzipper')
 const execa = require('execa')
 const installHelper = require('../../../src/lib/install-helper')
+const importHelper = require('../../../src/lib/import-helper')
 const { USER_CONFIG_FILE, DEPLOY_CONFIG_FILE } = require('../../../src/lib/defaults')
 const path = require('node:path')
 const jsYaml = require('js-yaml')
@@ -23,9 +24,16 @@ const jsYaml = require('js-yaml')
 jest.mock('fs-extra')
 jest.mock('unzipper')
 jest.mock('../../../src/lib/install-helper')
+jest.mock('../../../src/lib/import-helper')
 jest.mock('js-yaml')
 jest.mock('ora')
 jest.mock('execa')
+
+const mockGetFullConfig = jest.fn()
+
+beforeAll(() => {
+  jest.spyOn(BaseCommand.prototype, 'getFullConfig').mockImplementation(mockGetFullConfig)
+})
 
 const mockReadStreamPipe = jest.fn()
 const mockUnzipExtract = jest.fn()
@@ -73,6 +81,7 @@ beforeEach(() => {
   process.cwd = jest.fn().mockImplementation(() => fakeCwd)
   process.chdir.mockClear()
   process.cwd.mockClear()
+  mockGetFullConfig.mockClear()
 })
 
 test('exports', () => {
@@ -285,6 +294,7 @@ describe('run', () => {
     // since we already unit test the methods above, we mock it here
     command.validateZipDirectoryStructure = jest.fn()
     command.unzipFile = jest.fn()
+    command.addCodeDownloadAnnotation = jest.fn()
     command.validateConfig = jest.fn()
     command.runTests = jest.fn()
     command.npmInstall = jest.fn()
@@ -309,6 +319,7 @@ describe('run', () => {
     // we only reject one call, to simulate a subcommand failure
     command.validateZipDirectoryStructure = jest.fn()
     command.unzipFile = jest.fn()
+    command.addCodeDownloadAnnotation = jest.fn()
     command.validateConfig = jest.fn()
     command.npmInstall = jest.fn()
     command.error = jest.fn()
@@ -336,6 +347,7 @@ describe('run', () => {
     // we only reject one call, to simulate a subcommand failure
     command.validateZipDirectoryStructure = jest.fn()
     command.unzipFile = jest.fn()
+    command.addCodeDownloadAnnotation = jest.fn()
     command.validateConfig = jest.fn()
     command.npmInstall = jest.fn()
     command.error = jest.fn()
@@ -360,6 +372,7 @@ describe('run', () => {
     // since we already unit test the methods above, we mock it here
     command.validateZipDirectoryStructure = jest.fn()
     command.unzipFile = jest.fn()
+    command.addCodeDownloadAnnotation = jest.fn()
     command.validateConfig = jest.fn()
     command.runTests = jest.fn()
     command.npmInstall = jest.fn()
@@ -375,4 +388,82 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(fakeCwd).toEqual(path.resolve('my-dest-folder'))
   })
+})
+
+test('addCodeDownloadAnnotation: default', async () => {
+  const extConfig = fixtureJson('install/1.all.config.json')
+
+  importHelper.loadConfigFile.mockImplementation(() => {
+    return fixtureJson('install/1.ext.config-loaded.json')
+  })
+
+  const command = new TheCommand()
+  command.argv = []
+  await command.addCodeDownloadAnnotation('my-dest-folder', extConfig)
+
+  expect(importHelper.writeFile).toHaveBeenCalledWith(
+    path.join('my-dest-folder', 'src', 'dx-excshell-1', 'ext.config.yaml'),
+    jsYaml.dump(fixtureJson('install/1.annotation-added.config.json')),
+    { overwrite: true }
+  )
+})
+
+test('addCodeDownloadAnnotation: no annotations defined', async () => {
+  const extConfig = fixtureJson('install/1.all.config.json')
+  // should not have any annotations set
+  delete extConfig.all['dx/excshell/1'].manifest.full.packages['dx-excshell-1'].actions.generic.annotations
+
+  const fixtureLoaded = fixtureJson('install/1.ext.config-loaded.json')
+  delete fixtureLoaded.values.runtimeManifest.packages['dx-excshell-1'].actions.generic.annotations
+  const fixtureExpected = fixtureJson('install/1.annotation-added.config.json')
+  fixtureExpected.runtimeManifest.packages['dx-excshell-1'].actions.generic.annotations = {
+    'code-download': false
+  }
+
+  importHelper.loadConfigFile.mockReturnValue(fixtureLoaded)
+
+  const command = new TheCommand()
+  command.argv = []
+  await command.addCodeDownloadAnnotation('my-dest-folder', extConfig)
+
+  expect(importHelper.writeFile).toHaveBeenCalledWith(
+    path.join('my-dest-folder', 'src', 'dx-excshell-1', 'ext.config.yaml'),
+    jsYaml.dump(fixtureExpected),
+    { overwrite: true }
+  )
+})
+
+test('addCodeDownloadAnnotation: complex includes, multiple actions and extensions', async () => {
+  const extConfig = fixtureJson('install/5.all.config.json')
+
+  importHelper.loadConfigFile.mockImplementation(file => {
+    const retValues = {
+      [path.join('my-dest-folder', 'app.config.yaml')]: fixtureJson('install/5.app.config-loaded.json'),
+      [path.join('my-dest-folder', 'sub1.config.yaml')]: fixtureJson('install/5.sub1.config-loaded.json'),
+      [path.join('my-dest-folder', 'src', 'sub2.config.yaml')]: fixtureJson('install/5.sub2.config-loaded.json')
+    }
+    return retValues[file]
+  })
+
+  const command = new TheCommand()
+  command.argv = []
+  await command.addCodeDownloadAnnotation('my-dest-folder', extConfig)
+
+  expect(importHelper.writeFile).toHaveBeenCalledWith(
+    path.join('my-dest-folder', 'app.config.yaml'),
+    jsYaml.dump(fixtureJson('install/5.app.annotation-added.config.json')),
+    { overwrite: true }
+  )
+
+  expect(importHelper.writeFile).toHaveBeenCalledWith(
+    path.join('my-dest-folder', 'sub1.config.yaml'),
+    jsYaml.dump(fixtureJson('install/5.sub1.annotation-added.config.json')),
+    { overwrite: true }
+  )
+
+  expect(importHelper.writeFile).toHaveBeenCalledWith(
+    path.join('my-dest-folder', 'src', 'sub2.config.yaml'),
+    jsYaml.dump(fixtureJson('install/5.sub2.annotation-added.config.json')),
+    { overwrite: true }
+  )
 })

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -26,7 +26,6 @@ const execa = require('execa')
 const fs = require('fs-extra')
 const path = require('node:path')
 const importHelper = require('../../../src/lib/import-helper')
-const yaml = require('js-yaml')
 const archiver = require('archiver')
 
 // mocks
@@ -314,84 +313,6 @@ test('filesToPack', async () => {
   expect(filesToPack).toEqual(['fileA', 'fileB'])
 })
 
-test('addCodeDownloadAnnotation: default', async () => {
-  const extConfig = fixtureJson('pack/1.all.config.json')
-
-  importHelper.loadConfigFile.mockImplementation(() => {
-    return fixtureJson('pack/1.ext.config-loaded.json')
-  })
-
-  const command = new TheCommand()
-  command.argv = []
-  await command.addCodeDownloadAnnotation(extConfig)
-
-  expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'src', 'dx-excshell-1', 'ext.config.yaml'),
-    yaml.dump(fixtureJson('pack/1.annotation-added.config.json')),
-    { overwrite: true }
-  )
-})
-
-test('addCodeDownloadAnnotation: no annotations defined', async () => {
-  const extConfig = fixtureJson('pack/1.all.config.json')
-  // should not have any annotations set
-  delete extConfig.all['dx/excshell/1'].manifest.full.packages['dx-excshell-1'].actions.generic.annotations
-
-  const fixtureLoaded = fixtureJson('pack/1.ext.config-loaded.json')
-  delete fixtureLoaded.values.runtimeManifest.packages['dx-excshell-1'].actions.generic.annotations
-  const fixtureExpected = fixtureJson('pack/1.annotation-added.config.json')
-  fixtureExpected.runtimeManifest.packages['dx-excshell-1'].actions.generic.annotations = {
-    'code-download': false
-  }
-
-  importHelper.loadConfigFile.mockReturnValue(fixtureLoaded)
-
-  const command = new TheCommand()
-  command.argv = []
-  await command.addCodeDownloadAnnotation(extConfig)
-
-  expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'src', 'dx-excshell-1', 'ext.config.yaml'),
-    yaml.dump(fixtureExpected),
-    { overwrite: true }
-  )
-})
-
-test('addCodeDownloadAnnotation: complex includes, multiple actions and extensions', async () => {
-  const extConfig = fixtureJson('pack/5.all.config.json')
-
-  importHelper.loadConfigFile.mockImplementation(file => {
-    const retValues = {
-      [path.join('app-package', 'app.config.yaml')]: fixtureJson('pack/5.app.config-loaded.json'),
-      [path.join('app-package', 'sub1.config.yaml')]: fixtureJson('pack/5.sub1.config-loaded.json'),
-      [path.join('app-package', 'src', 'sub2.config.yaml')]: fixtureJson('pack/5.sub2.config-loaded.json')
-    }
-    return retValues[file]
-  })
-
-  const command = new TheCommand()
-  command.argv = []
-  await command.addCodeDownloadAnnotation(extConfig)
-
-  expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'app.config.yaml'),
-    yaml.dump(fixtureJson('pack/5.app.annotation-added.config.json')),
-    { overwrite: true }
-  )
-
-  expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'sub1.config.yaml'),
-    yaml.dump(fixtureJson('pack/5.sub1.annotation-added.config.json')),
-    { overwrite: true }
-  )
-
-  expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'src', 'sub2.config.yaml'),
-    yaml.dump(fixtureJson('pack/5.sub2.annotation-added.config.json')),
-    { overwrite: true }
-  )
-})
-
 describe('run', () => {
   test('defaults', async () => {
     mockGetFullConfig.mockImplementation(() => fixtureJson('pack/1.all.config.json'))
@@ -403,7 +324,6 @@ describe('run', () => {
     command.copyPackageFiles = jest.fn()
     command.filesToPack = jest.fn()
     command.createDeployYamlFile = jest.fn()
-    command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn()
     const runHook = jest.fn()
     command.config = { runHook }
@@ -412,7 +332,6 @@ describe('run', () => {
     expect(command.copyPackageFiles).toHaveBeenCalledTimes(1)
     expect(command.filesToPack).toHaveBeenCalledTimes(1)
     expect(command.createDeployYamlFile).toHaveBeenCalledTimes(1)
-    expect(command.addCodeDownloadAnnotation).toHaveBeenCalledTimes(1)
     expect(command.zipHelper).toHaveBeenCalledTimes(1)
     const expectedObj = {
       artifactsFolder: 'app-package',
@@ -434,7 +353,6 @@ describe('run', () => {
     command.copyPackageFiles = jest.fn()
     command.filesToPack = jest.fn()
     command.createDeployYamlFile = jest.fn()
-    command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn(() => { throw errorObject })
     command.error = jest.fn()
     const runHook = jest.fn()
@@ -445,7 +363,6 @@ describe('run', () => {
     expect(command.copyPackageFiles).toHaveBeenCalledTimes(1)
     expect(command.filesToPack).toHaveBeenCalledTimes(1)
     expect(command.createDeployYamlFile).toHaveBeenCalledTimes(1)
-    expect(command.addCodeDownloadAnnotation).toHaveBeenCalledTimes(1)
     expect(command.zipHelper).toHaveBeenCalledTimes(1)
     expect(command.error).toHaveBeenCalledTimes(1)
 
@@ -470,7 +387,6 @@ describe('run', () => {
     command.copyPackageFiles = jest.fn()
     command.filesToPack = jest.fn()
     command.createDeployYamlFile = jest.fn()
-    command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn(() => { throw new Error(errorMessage) })
     command.error = jest.fn()
     const runHook = jest.fn()
@@ -481,7 +397,6 @@ describe('run', () => {
     expect(command.copyPackageFiles).toHaveBeenCalledTimes(1)
     expect(command.filesToPack).toHaveBeenCalledTimes(1)
     expect(command.createDeployYamlFile).toHaveBeenCalledTimes(1)
-    expect(command.addCodeDownloadAnnotation).toHaveBeenCalledTimes(1)
     expect(command.zipHelper).toHaveBeenCalledTimes(1)
     expect(command.error).toHaveBeenCalledTimes(1)
 
@@ -504,7 +419,6 @@ describe('run', () => {
     command.copyPackageFiles = jest.fn()
     command.filesToPack = jest.fn()
     command.createDeployYamlFile = jest.fn()
-    command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn()
     const runHook = jest.fn()
     command.config = { runHook }
@@ -514,7 +428,6 @@ describe('run', () => {
     expect(command.copyPackageFiles).toHaveBeenCalledTimes(1)
     expect(command.filesToPack).toHaveBeenCalledTimes(1)
     expect(command.createDeployYamlFile).toHaveBeenCalledTimes(1)
-    expect(command.addCodeDownloadAnnotation).toHaveBeenCalledTimes(1)
     expect(command.zipHelper).toHaveBeenCalledTimes(1)
 
     const expectedObj = {


### PR DESCRIPTION
## Description

Currently, the `disableCodeDownload` annotation is added to all actions when an app is packed (`aio app pack`) to prevent users who install App Builder apps from downloading action code

This PR proposes adding the annotation at install time (`aio app install`) instead

## Related Issue

## Motivation and Context

Users can technically modify the app zip after `aio app pack` has run. This change guarantees that all installed App Builder apps have action code download disabled

## How Has This Been Tested?

- `npm run test`
- Pack and install routine with both standalone and excshell app

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
