### PR TITLE
remove isv dev details from mesh config while packing

### DIFF
--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -135,7 +135,7 @@ class Pack extends BaseCommand {
         const { stdout } = await execa('aio', ['api-mesh', 'get'], { cwd: process.cwd() })
         // until we get the --json flag, we parse the output
         const idx = stdout.indexOf('{')
-        meshConfig = JSON.parse(stdout.substring(idx))
+        meshConfig = JSON.parse(stdout.substring(idx)).meshConfig
         aioLogger.debug(`api-mesh:get - ${JSON.stringify(meshConfig, null, 2)}`)
         this.spinner.succeed('Got api-mesh config')
       } catch (err) {

--- a/test/__fixtures__/pack/2.deploy.yaml
+++ b/test/__fixtures__/pack/2.deploy.yaml
@@ -12,19 +12,9 @@ apis:
   - code: AudienceManagerCustomerSDK
   - code: GraphQLServiceSDK
 meshConfig:
-  lastUpdated: '2023-03-02T09:58:23.896Z'
-  meshConfig:
-    sources:
-      - name: Commerce
-        handler:
-          graphql:
-            endpoint: https://foo.bar/graphql/
-  meshId: abcd123
-  lastUpdatedBy:
-    firstName: John
-    lastName: Doe
-    userEmail: john.doe@fakedomain.net
-    userId: 123456@a3151.astaagq3
-    displayName: John Doe
-  meshStatus: success
+  sources:
+    - name: Commerce
+      handler:
+        graphql:
+          endpoint: https://foo.bar/graphql/
 runtime: true


### PR DESCRIPTION
## Description

This PR removes application developer details from the `meshConfig` portion of `deploy.yaml`, generated when the developer runs `aio app pack`

The `api-mesh get` command returns information about the application developer, which can be omitted from `deploy.yaml` since a new mesh config can be created with only the data in the `meshConfig` key

```
{
  "lastUpdated": "2023-08-29T16:20:01.202Z",
  "meshConfig": {
    "sources": [
      {
        "name": "Commerce",
        "handler": {
          "graphql": {
            "endpoint": "https://venia.magento.com/graphql/"
          }
        }
      }
    ]
  },
  "meshId": "ee487aab-e92e-4035-a757-e18858ef7a92",
  "lastUpdatedBy": {
    "firstName": "Michael",
    "lastName": "Goberling",
    "userEmail": "mgoberling@adobe.com",
    "userId": "4E561E5C62E3F21E0A494122@AdobeID",
    "displayName": "Michael%20Goberling"
  },
  "meshStatus": "success",
  "meshURL": ""
}
```

## Related Issue

## Motivation and Context

Security

## How Has This Been Tested?

`npm run test`, locally linked plugin 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
