### PR TITLE
Call events template with additional option events-config-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-lib-templates": "^2.2.0",
     "@adobe/aio-lib-web": "^6.1.0",
     "@adobe/generator-aio-app": "^5.1.0",
-    "@adobe/generator-app-common-lib": "file:../TemplateRegistry/generator-app-common-lib",
+    "@adobe/generator-app-common-lib": "^0.4.5",
     "@adobe/inquirer-table-checkbox": "^1.2.0",
     "@oclif/core": "^2.11.6",
     "@parcel/core": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-lib-templates": "^2.2.0",
     "@adobe/aio-lib-web": "^6.1.0",
     "@adobe/generator-aio-app": "^5.1.0",
-    "@adobe/generator-app-common-lib": "^0.4.0",
+    "@adobe/generator-app-common-lib": "file:../TemplateRegistry/generator-app-common-lib",
     "@adobe/inquirer-table-checkbox": "^1.2.0",
     "@oclif/core": "^2.11.6",
     "@parcel/core": "^2.7.0",

--- a/src/commands/app/add/event.js
+++ b/src/commands/app/add/event.js
@@ -47,6 +47,7 @@ class AddEventCommand extends TemplatesCommand {
     if (flags['experimental-allow-events-templates']) {
       const eventsData = this.getEventsConfigFile(configName)
       templateOptions['full-key-to-events-manifest'] = eventsData.key
+      templateOptions['events-config-path'] = eventsData.file
       const [searchCriteria, orderByCriteria] = await this.getSearchCriteria()
       const templates = await this.selectTemplates(searchCriteria, orderByCriteria)
       if (templates.length === 0) {


### PR DESCRIPTION
This fix adds event registrations in the app config file under the desired extension 

## Description

Use event-config-path to add event registrations in the config file

## Related Issue

https://github.com/adobe/generator-app-common-lib/pull/48

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
