### PR TITLE
fix: ACNA-2561 - app pack command should exclude hidden files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "term-size": "^2.2.1",
     "unzipper": "^0.10.11",
     "upath": "^2",
+    "junk": "^3.1.0",
     "which": "^3.0.0",
     "yeoman-environment": "^3.2.0"
   },

--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -21,6 +21,7 @@ const { loadConfigFile, writeFile } = require('../../lib/import-helper')
 const { getObjectValue } = require('../../lib/app-helper')
 const ora = require('ora')
 const chalk = require('chalk')
+const junk = require('junk')
 
 // eslint-disable-next-line node/no-missing-require
 const libConfigNext = require('@adobe/aio-cli-lib-app-config-next')
@@ -250,6 +251,8 @@ class Pack extends BaseCommand {
     return files
       .map(file => file.path)
       .filter(file => !filesToExclude.includes(file))
+      .filter(junk.not) // no junk files like .DS_Store
+      .filter((file) => !/^\..*/.test(file)) // no files that start with a '.'
   }
 
   /**

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -464,7 +464,7 @@ describe('run', () => {
 
     // since we already unit test the methods above, we mock it here
     command.copyPackageFiles = jest.fn()
-    command.filesToPack = jest.fn()
+    command.filesToPack = jest.fn(() => (['some-file']))
     command.createDeployYamlFile = jest.fn()
     command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn()
@@ -495,7 +495,7 @@ describe('run', () => {
 
     // since we already unit test the methods above, we mock it here
     command.copyPackageFiles = jest.fn()
-    command.filesToPack = jest.fn()
+    command.filesToPack = jest.fn(() => ([]))
     command.createDeployYamlFile = jest.fn()
     command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn(() => { throw errorObject })
@@ -531,7 +531,7 @@ describe('run', () => {
 
     // since we already unit test the methods above, we mock it here
     command.copyPackageFiles = jest.fn()
-    command.filesToPack = jest.fn()
+    command.filesToPack = jest.fn(() => ([]))
     command.createDeployYamlFile = jest.fn()
     command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn(() => { throw new Error(errorMessage) })
@@ -565,7 +565,7 @@ describe('run', () => {
 
     // since we already unit test the methods above, we mock it here
     command.copyPackageFiles = jest.fn()
-    command.filesToPack = jest.fn()
+    command.filesToPack = jest.fn(() => ([]))
     command.createDeployYamlFile = jest.fn()
     command.addCodeDownloadAnnotation = jest.fn()
     command.zipHelper = jest.fn()
@@ -596,7 +596,7 @@ describe('run', () => {
 
     // since we already unit test the methods above, we mock it here
     command.copyPackageFiles = jest.fn()
-    command.filesToPack = jest.fn()
+    command.filesToPack = jest.fn(() => ([]))
     command.createDeployYamlFile = jest.fn()
     command.zipHelper = jest.fn()
     const runHook = jest.fn()

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -310,24 +310,71 @@ test('zipHelper', async () => {
   onError()
 })
 
-test('filesToPack', async () => {
-  const jsonOutput = [{
-    files: [
-      { path: 'fileA' },
-      { path: 'fileB' }
-    ]
-  }]
+describe('filesToPack', () => {
+  test('nothing filtered', async () => {
+    const jsonOutput = [{
+      files: [
+        { path: 'fileA' },
+        { path: 'fileB' }
+      ]
+    }]
 
-  execa.mockImplementationOnce((cmd, args) => {
-    expect(cmd).toEqual('npm')
-    expect(args).toEqual(['pack', '--dry-run', '--json'])
-    return { stdout: JSON.stringify(jsonOutput, null, 2) }
+    execa.mockImplementationOnce((cmd, args) => {
+      expect(cmd).toEqual('npm')
+      expect(args).toEqual(['pack', '--dry-run', '--json'])
+      return { stdout: JSON.stringify(jsonOutput, null, 2) }
+    })
+
+    const command = new TheCommand()
+    command.argv = []
+    const filesToPack = await command.filesToPack()
+    expect(filesToPack).toEqual(['fileA', 'fileB'])
   })
 
-  const command = new TheCommand()
-  command.argv = []
-  const filesToPack = await command.filesToPack()
-  expect(filesToPack).toEqual(['fileA', 'fileB'])
+  test('filter for hidden files', async () => {
+    const jsonOutput = [{
+      files: [
+        { path: '.env' },
+        { path: '.aio' },
+        { path: '.foo' },
+        { path: 'fileA' },
+        { path: 'fileB' }
+      ]
+    }]
+
+    execa.mockImplementationOnce((cmd, args) => {
+      expect(cmd).toEqual('npm')
+      expect(args).toEqual(['pack', '--dry-run', '--json'])
+      return { stdout: JSON.stringify(jsonOutput, null, 2) }
+    })
+
+    const command = new TheCommand()
+    command.argv = []
+    const filesToPack = await command.filesToPack()
+    expect(filesToPack).toEqual(['fileA', 'fileB'])
+  })
+
+  test('filter for junk files', async () => {
+    const jsonOutput = [{
+      files: [
+        { path: '.DS_Store' },
+        { path: 'Thumbs.db' },
+        { path: 'fileA' },
+        { path: 'fileB' }
+      ]
+    }]
+
+    execa.mockImplementationOnce((cmd, args) => {
+      expect(cmd).toEqual('npm')
+      expect(args).toEqual(['pack', '--dry-run', '--json'])
+      return { stdout: JSON.stringify(jsonOutput, null, 2) }
+    })
+
+    const command = new TheCommand()
+    command.argv = []
+    const filesToPack = await command.filesToPack()
+    expect(filesToPack).toEqual(['fileA', 'fileB'])
+  })
 })
 
 test('addCodeDownloadAnnotation: default', async () => {


### PR DESCRIPTION
Currently the files to be packed are defined by `npm pack --dry-run --json` and exclusions are defined by the `.gitignore` file. However, if the app folder does not have `.gitignore`, certain sensitive files may still be included. This PR will exclude these files no matter what.

These files are excluded from being packed:
1. any "hidden" file by convention (file that starts with a '.')
2. any junk file as defined by https://www.npmjs.com/package/junk

## How Has This Been Tested?

npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
