### PR TITLE
fix: ACNA-2562 - artifacts and zip output should be in a .gitignored dist folder

### DIFF
--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -26,10 +26,11 @@ const junk = require('junk')
 // eslint-disable-next-line node/no-missing-require
 const libConfigNext = require('@adobe/aio-cli-lib-app-config-next')
 
+const DIST_FOLDER = 'dist'
 const DEFAULTS = {
-  OUTPUT_ZIP_FILE: 'app.zip',
-  ARTIFACTS_FOLDER: 'app-package',
-  DEPLOY_YAML_FILE: 'deploy.yaml'
+  OUTPUT_ZIP_FILE_PATH: path.join(DIST_FOLDER, 'app.zip'),
+  ARTIFACTS_FOLDER_PATH: path.join(DIST_FOLDER, 'app-package'),
+  DEPLOY_YAML_FILE_NAME: 'deploy.yaml'
 }
 
 class Pack extends BaseCommand {
@@ -54,18 +55,22 @@ class Pack extends BaseCommand {
       aioLogger.debug(`changed current working directory to: ${resolvedPath}`)
     }
 
+    // get all 'dist' locations of all extensions (relative to the current working directory)
+    const distLocations = Object.entries(appConfig.all)
+      .map(([, extConfig]) => path.relative(process.cwd(), extConfig.app.dist))
+
     try {
       // 1. create artifacts phase
-      this.spinner.start(`Creating package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER}'...`)
-      await fs.emptyDir(DEFAULTS.ARTIFACTS_FOLDER)
-      this.spinner.succeed(`Created package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER}'`)
+      this.spinner.start(`Creating package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}'...`)
+      await fs.emptyDir(DEFAULTS.ARTIFACTS_FOLDER_PATH)
+      this.spinner.succeed(`Created package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}'`)
 
       // ACNA-2038
       // not artifacts folder should exist before we fire the event
-      await this.config.runHook('pre-pack', { appConfig, artifactsFolder: DEFAULTS.ARTIFACTS_FOLDER })
+      await this.config.runHook('pre-pack', { appConfig, artifactsFolder: DEFAULTS.ARTIFACTS_FOLDER_PATH })
 
       // 1a. Get file list to pack
-      const fileList = await this.filesToPack([flags.output])
+      const fileList = await this.filesToPack([flags.output, DEFAULTS.DIST_FOLDER, ...distLocations])
       this.log('=== Files to pack ===')
       fileList.forEach((file) => {
         this.log(`  ${file}`)
@@ -75,7 +80,7 @@ class Pack extends BaseCommand {
       // 2. copy files to package phase
       this.spinner.start('Copying project files...')
 
-      await this.copyPackageFiles(DEFAULTS.ARTIFACTS_FOLDER, fileList)
+      await this.copyPackageFiles(DEFAULTS.ARTIFACTS_FOLDER_PATH, fileList)
       this.spinner.succeed('Copied project files')
 
       // 3. add/modify artifacts phase
@@ -88,13 +93,18 @@ class Pack extends BaseCommand {
       this.spinner.succeed('Added code-download annotations')
 
       // doing this before zip so other things can be added to the zip
-      await this.config.runHook('post-pack', { appConfig, artifactsFolder: DEFAULTS.ARTIFACTS_FOLDER })
+      await this.config.runHook('post-pack', { appConfig, artifactsFolder: DEFAULTS.ARTIFACTS_FOLDER_PATH })
 
       // 4. zip package phase
-      this.spinner.start(`Zipping package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER}' to '${outputZipFile}'...`)
+      this.spinner.start(`Zipping package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}' to '${outputZipFile}'...`)
       await fs.remove(outputZipFile)
-      await this.zipHelper(DEFAULTS.ARTIFACTS_FOLDER, outputZipFile)
-      this.spinner.succeed(`Zipped package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER}' to '${outputZipFile}'`)
+      await this.zipHelper(DEFAULTS.ARTIFACTS_FOLDER_PATH, outputZipFile)
+      this.spinner.succeed(`Zipped package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}' to '${outputZipFile}'`)
+
+      // 5. finally delete the artifacts folder
+      this.spinner.start(`Deleting package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}'...`)
+      await fs.remove(DEFAULTS.ARTIFACTS_FOLDER_PATH)
+      this.spinner.succeed(`Deleted package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}'`)
     } catch (e) {
       this.spinner.fail(e.message)
       this.error(flags.verbose ? e : e.message)
@@ -185,7 +195,7 @@ class Pack extends BaseCommand {
     }
 
     await writeFile(
-      path.join(DEFAULTS.ARTIFACTS_FOLDER, DEFAULTS.DEPLOY_YAML_FILE),
+      path.join(DEFAULTS.ARTIFACTS_FOLDER_PATH, DEFAULTS.DEPLOY_YAML_FILE_NAME),
       yaml.dump(deployJson),
       { overwrite: true })
   }
@@ -320,7 +330,7 @@ class Pack extends BaseCommand {
 
     // rewrite config files
     for (const [file, keys] of Object.entries(fileToAnnotationKey)) {
-      const configFilePath = path.join(DEFAULTS.ARTIFACTS_FOLDER, file)
+      const configFilePath = path.join(DEFAULTS.ARTIFACTS_FOLDER_PATH, file)
       const { values } = loadConfigFile(configFilePath)
 
       keys.forEach(key => {
@@ -350,7 +360,7 @@ Pack.flags = {
   output: Flags.string({
     description: 'The packaged app output file path',
     char: 'o',
-    default: DEFAULTS.OUTPUT_ZIP_FILE
+    default: DEFAULTS.OUTPUT_ZIP_FILE_PATH
   })
 }
 

--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -70,7 +70,7 @@ class Pack extends BaseCommand {
       await this.config.runHook('pre-pack', { appConfig, artifactsFolder: DEFAULTS.ARTIFACTS_FOLDER_PATH })
 
       // 1a. Get file list to pack
-      const fileList = await this.filesToPack([flags.output, DEFAULTS.DIST_FOLDER, ...distLocations])
+      const fileList = await this.filesToPack({ filesToExclude: [flags.output, DEFAULTS.DIST_FOLDER, ...distLocations] })
       this.log('=== Files to pack ===')
       fileList.forEach((file) => {
         this.log(`  ${file}`)
@@ -258,11 +258,12 @@ class Pack extends BaseCommand {
    *
    * This runs `npm pack` to get the list.
    *
-   * @param {Array<string>} filesToExclude a list of files to exclude
-   * @param {string} workingDirectory the working directory to run `npm pack` in
+   * @param {object} options the options for the method
+   * @param {Array<string>} options.filesToExclude a list of files to exclude
+   * @param {string} options.workingDirectory the working directory to run `npm pack` in
    * @returns {Array<string>} a list of files that are to be packed
    */
-  async filesToPack (filesToExclude = [], workingDirectory = process.cwd()) {
+  async filesToPack ({ filesToExclude = [], workingDirectory = process.cwd() } = {}) {
     const { stdout } = await execa('npm', ['pack', '--dry-run', '--json'], { cwd: workingDirectory })
 
     const noJunkFiles = (file) => {

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -96,7 +96,7 @@ test('flags', async () => {
   expect(typeof TheCommand.flags.output).toBe('object')
   expect(typeof TheCommand.flags.output.type).toBe('string')
   expect(typeof TheCommand.flags.output.description).toBe('string')
-  expect(TheCommand.flags.output.default).toBe('app.zip')
+  expect(TheCommand.flags.output.default).toBe(path.join('dist', 'app.zip'))
 })
 
 test('unknown flag', async () => {
@@ -147,7 +147,7 @@ test('createDeployYamlFile (1 extension)', async () => {
 
   await command.createDeployYamlFile(extConfig)
 
-  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('app-package', 'deploy.yaml'))
+  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('dist', 'app-package', 'deploy.yaml'))
   await expect(importHelper.writeFile.mock.calls[0][1]).toMatchFixture('pack/2.deploy.yaml')
   await expect(importHelper.writeFile.mock.calls[0][2]).toMatchObject({ overwrite: true })
 
@@ -161,7 +161,7 @@ test('createDeployYamlFile (1 extension)', async () => {
 
   await command.createDeployYamlFile(extConfig)
 
-  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('app-package', 'deploy.yaml'))
+  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('dist', 'app-package', 'deploy.yaml'))
   await expect(importHelper.writeFile.mock.calls[0][1]).toMatchFixture('pack/2.deploy.no-mesh.yaml')
   await expect(importHelper.writeFile.mock.calls[0][2]).toMatchObject({ overwrite: true })
 })
@@ -188,7 +188,7 @@ test('createDeployYamlFile (1 extension), no api-mesh', async () => {
 
   await command.createDeployYamlFile(extConfig)
 
-  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('app-package', 'deploy.yaml'))
+  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('dist', 'app-package', 'deploy.yaml'))
   await expect(importHelper.writeFile.mock.calls[0][1]).toMatchFixture('pack/2.deploy.no-mesh.yaml')
   await expect(importHelper.writeFile.mock.calls[0][2]).toMatchObject({ overwrite: true })
 })
@@ -231,7 +231,7 @@ test('createDeployYamlFile (coverage: standalone app, no services)', async () =>
 
   await command.createDeployYamlFile(extConfig)
 
-  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('app-package', 'deploy.yaml'))
+  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('dist', 'app-package', 'deploy.yaml'))
   await expect(importHelper.writeFile.mock.calls[0][1]).toMatchFixture('pack/4.deploy.yaml')
   await expect(importHelper.writeFile.mock.calls[0][2]).toMatchObject({ overwrite: true })
 })
@@ -389,7 +389,7 @@ test('addCodeDownloadAnnotation: default', async () => {
   await command.addCodeDownloadAnnotation(extConfig)
 
   expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'src', 'dx-excshell-1', 'ext.config.yaml'),
+    path.join('dist', 'app-package', 'src', 'dx-excshell-1', 'ext.config.yaml'),
     yaml.dump(fixtureJson('pack/1.annotation-added.config.json')),
     { overwrite: true }
   )
@@ -414,7 +414,7 @@ test('addCodeDownloadAnnotation: no annotations defined', async () => {
   await command.addCodeDownloadAnnotation(extConfig)
 
   expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'src', 'dx-excshell-1', 'ext.config.yaml'),
+    path.join('dist', 'app-package', 'src', 'dx-excshell-1', 'ext.config.yaml'),
     yaml.dump(fixtureExpected),
     { overwrite: true }
   )
@@ -425,9 +425,9 @@ test('addCodeDownloadAnnotation: complex includes, multiple actions and extensio
 
   importHelper.loadConfigFile.mockImplementation(file => {
     const retValues = {
-      [path.join('app-package', 'app.config.yaml')]: fixtureJson('pack/5.app.config-loaded.json'),
-      [path.join('app-package', 'sub1.config.yaml')]: fixtureJson('pack/5.sub1.config-loaded.json'),
-      [path.join('app-package', 'src', 'sub2.config.yaml')]: fixtureJson('pack/5.sub2.config-loaded.json')
+      [path.join('dist', 'app-package', 'app.config.yaml')]: fixtureJson('pack/5.app.config-loaded.json'),
+      [path.join('dist', 'app-package', 'sub1.config.yaml')]: fixtureJson('pack/5.sub1.config-loaded.json'),
+      [path.join('dist', 'app-package', 'src', 'sub2.config.yaml')]: fixtureJson('pack/5.sub2.config-loaded.json')
     }
     return retValues[file]
   })
@@ -437,19 +437,19 @@ test('addCodeDownloadAnnotation: complex includes, multiple actions and extensio
   await command.addCodeDownloadAnnotation(extConfig)
 
   expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'app.config.yaml'),
+    path.join('dist', 'app-package', 'app.config.yaml'),
     yaml.dump(fixtureJson('pack/5.app.annotation-added.config.json')),
     { overwrite: true }
   )
 
   expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'sub1.config.yaml'),
+    path.join('dist', 'app-package', 'sub1.config.yaml'),
     yaml.dump(fixtureJson('pack/5.sub1.annotation-added.config.json')),
     { overwrite: true }
   )
 
   expect(importHelper.writeFile).toHaveBeenCalledWith(
-    path.join('app-package', 'src', 'sub2.config.yaml'),
+    path.join('dist', 'app-package', 'src', 'sub2.config.yaml'),
     yaml.dump(fixtureJson('pack/5.sub2.annotation-added.config.json')),
     { overwrite: true }
   )
@@ -478,7 +478,7 @@ describe('run', () => {
     expect(command.addCodeDownloadAnnotation).toHaveBeenCalledTimes(1)
     expect(command.zipHelper).toHaveBeenCalledTimes(1)
     const expectedObj = {
-      artifactsFolder: 'app-package',
+      artifactsFolder: path.join('dist', 'app-package'),
       appConfig: expect.any(Object)
     }
     expect(runHook).toHaveBeenCalledWith('pre-pack', expectedObj)
@@ -513,7 +513,7 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledTimes(1)
 
     const expectedObj = {
-      artifactsFolder: 'app-package',
+      artifactsFolder: path.join('dist', 'app-package'),
       appConfig: expect.any(Object)
     }
     expect(runHook).toHaveBeenCalledWith('pre-pack', expectedObj)
@@ -549,7 +549,7 @@ describe('run', () => {
     expect(command.error).toHaveBeenCalledTimes(1)
 
     const expectedObj = {
-      artifactsFolder: 'app-package',
+      artifactsFolder: path.join('dist', 'app-package'),
       appConfig: expect.any(Object)
     }
     expect(runHook).toHaveBeenCalledWith('pre-pack', expectedObj)
@@ -581,7 +581,7 @@ describe('run', () => {
     expect(command.zipHelper).toHaveBeenCalledTimes(1)
 
     const expectedObj = {
-      artifactsFolder: 'app-package',
+      artifactsFolder: path.join('dist', 'app-package'),
       appConfig: expect.any(Object)
     }
     expect(runHook).toHaveBeenCalledWith('pre-pack', expectedObj)

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -331,6 +331,26 @@ describe('filesToPack', () => {
     expect(filesToPack).toEqual(['fileA', 'fileB'])
   })
 
+  test('exclude specific file', async () => {
+    const jsonOutput = [{
+      files: [
+        { path: 'fileA' },
+        { path: 'fileB' }
+      ]
+    }]
+
+    execa.mockImplementationOnce((cmd, args) => {
+      expect(cmd).toEqual('npm')
+      expect(args).toEqual(['pack', '--dry-run', '--json'])
+      return { stdout: JSON.stringify(jsonOutput, null, 2) }
+    })
+
+    const command = new TheCommand()
+    command.argv = []
+    const filesToPack = await command.filesToPack({ filesToExclude: ['fileA'] })
+    expect(filesToPack).toEqual(['fileB'])
+  })
+
   test('filter for hidden files', async () => {
     const jsonOutput = [{
       files: [


### PR DESCRIPTION
These files have been moved:
1. `app-package` artifacts folder has been moved to `dist/app-package`
2. the default output `app.zip` has been moved to `dist/app.zip`.

This has been added:
1. all extension `dist` folders are excluded from the pack
2. the `dist` folder itself is excluded from the pack (just in case the .gitignore value is not there)
3. the `dist/app-package` folder will be deleted after the pack

## How Has This Been Tested?

1. npm test
2. `aio app pack` on an App Builder project
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
