### PR TITLE
feat: add tests flag to install command

### DIFF
--- a/src/commands/app/install.js
+++ b/src/commands/app/install.js
@@ -55,7 +55,9 @@ class InstallCommand extends BaseCommand {
       await this.validateAppConfig(outputPath, USER_CONFIG_FILE)
       await this.validateDeployConfig(outputPath, DEPLOY_CONFIG_FILE)
       await this.npmInstall(flags.verbose)
-      await this.runTests()
+      if (flags.tests) {
+        await this.runTests()
+      }
       this.spinner.succeed('Install done.')
     } catch (e) {
       this.spinner.fail(e.message)
@@ -164,6 +166,11 @@ InstallCommand.flags = {
     description: 'The packaged app output folder path',
     char: 'o',
     default: '.'
+  }),
+  tests: Flags.boolean({
+    description: 'Run packaged app unit tests (e.g. aio app:test)',
+    default: true,
+    allowNo: true
   })
 }
 

--- a/test/commands/app/install.test.js
+++ b/test/commands/app/install.test.js
@@ -413,4 +413,56 @@ describe('run', () => {
     await command.run()
     expect(command.spinner.fail).toHaveBeenCalledWith('fake validation error')
   })
+
+  test('flag --tests', async () => {
+    const command = new TheCommand()
+    command.argv = ['my-app.zip', '--output', 'my-dest-folder', '--tests']
+
+    // since we already unit test the methods above, we mock it here
+    command.validateZipDirectoryStructure = jest.fn()
+    command.unzipFile = jest.fn()
+    command.addCodeDownloadAnnotation = jest.fn()
+    command.validateDeployConfig = jest.fn()
+    command.runTests = jest.fn()
+    command.npmInstall = jest.fn()
+    command.error = jest.fn()
+
+    await command.run()
+
+    expect(command.validateZipDirectoryStructure).toHaveBeenCalledTimes(1)
+    expect(command.unzipFile).toHaveBeenCalledTimes(1)
+    expect(libConfigNext.coalesce).toHaveBeenCalledTimes(1)
+    expect(libConfigNext.validate).toHaveBeenCalledTimes(1)
+    expect(command.validateDeployConfig).toHaveBeenCalledTimes(1)
+    expect(command.runTests).toHaveBeenCalledTimes(1)
+    expect(command.npmInstall).toHaveBeenCalledTimes(1)
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(fakeCwd).toEqual(path.resolve('my-dest-folder'))
+  })
+
+  test('flag --no-tests', async () => {
+    const command = new TheCommand()
+    command.argv = ['my-app.zip', '--output', 'my-dest-folder', '--no-tests']
+
+    // since we already unit test the methods above, we mock it here
+    command.validateZipDirectoryStructure = jest.fn()
+    command.unzipFile = jest.fn()
+    command.addCodeDownloadAnnotation = jest.fn()
+    command.validateDeployConfig = jest.fn()
+    command.runTests = jest.fn()
+    command.npmInstall = jest.fn()
+    command.error = jest.fn()
+
+    await command.run()
+
+    expect(command.validateZipDirectoryStructure).toHaveBeenCalledTimes(1)
+    expect(command.unzipFile).toHaveBeenCalledTimes(1)
+    expect(libConfigNext.coalesce).toHaveBeenCalledTimes(1)
+    expect(libConfigNext.validate).toHaveBeenCalledTimes(1)
+    expect(command.validateDeployConfig).toHaveBeenCalledTimes(1)
+    expect(command.runTests).toHaveBeenCalledTimes(0)
+    expect(command.npmInstall).toHaveBeenCalledTimes(1)
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(fakeCwd).toEqual(path.resolve('my-dest-folder'))
+  })
 })


### PR DESCRIPTION
## Description

Sometimes users want to skip running tests when running `aio app install`

This PR proposes adding `--tests` and `--no-tests` flags for users 

## Related Issue

## Motivation and Context

## How Has This Been Tested?

Locally linked plugin, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
