### PR TITLE
fix: ACNA-2800 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ $ aio app --help
 * [`aio app get-url [ACTION]`](#aio-app-get-url-action)
 * [`aio app info`](#aio-app-info)
 * [`aio app init [PATH]`](#aio-app-init-path)
+* [`aio app install PATH`](#aio-app-install-path)
 * [`aio app list`](#aio-app-list)
 * [`aio app list extension`](#aio-app-list-extension)
 * [`aio app logs`](#aio-app-logs)
+* [`aio app pack [PATH]`](#aio-app-pack-path)
 * [`aio app run`](#aio-app-run)
 * [`aio app test`](#aio-app-test)
 * [`aio app undeploy`](#aio-app-undeploy)
@@ -70,7 +72,7 @@ DESCRIPTION
   Create, run, test, and deploy Adobe I/O Apps
 ```
 
-_See code: [src/commands/app/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/index.ts)_
+_See code: [src/commands/app/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/index.js)_
 
 ## `aio app add`
 
@@ -88,7 +90,7 @@ DESCRIPTION
   Add a new component to an existing Adobe I/O App
 ```
 
-_See code: [src/commands/app/add/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/index.ts)_
+_See code: [src/commands/app/add/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/index.js)_
 
 ## `aio app add action`
 
@@ -113,7 +115,7 @@ ALIASES
   $ aio app add actions
 ```
 
-_See code: [src/commands/app/add/action.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/action.ts)_
+_See code: [src/commands/app/add/action.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/action.js)_
 
 ## `aio app add ci`
 
@@ -131,7 +133,7 @@ DESCRIPTION
   Add CI files
 ```
 
-_See code: [src/commands/app/add/ci.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/ci.ts)_
+_See code: [src/commands/app/add/ci.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/ci.js)_
 
 ## `aio app add event`
 
@@ -156,7 +158,7 @@ ALIASES
   $ aio app add events
 ```
 
-_See code: [src/commands/app/add/event.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/event.ts)_
+_See code: [src/commands/app/add/event.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/event.js)_
 
 ## `aio app add extension`
 
@@ -182,7 +184,7 @@ ALIASES
   $ aio app add extensions
 ```
 
-_See code: [src/commands/app/add/extension.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/extension.ts)_
+_See code: [src/commands/app/add/extension.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/extension.js)_
 
 ## `aio app add service`
 
@@ -206,7 +208,7 @@ ALIASES
   $ aio app add services
 ```
 
-_See code: [src/commands/app/add/service.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/service.ts)_
+_See code: [src/commands/app/add/service.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/service.js)_
 
 ## `aio app add web-assets`
 
@@ -227,7 +229,7 @@ DESCRIPTION
   Add web assets support
 ```
 
-_See code: [src/commands/app/add/web-assets.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/web-assets.ts)_
+_See code: [src/commands/app/add/web-assets.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/add/web-assets.js)_
 
 ## `aio app build`
 
@@ -256,7 +258,7 @@ DESCRIPTION
   This will always force a rebuild unless --no-force-build is set.
 ```
 
-_See code: [src/commands/app/build.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/build.ts)_
+_See code: [src/commands/app/build.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/build.js)_
 
 ## `aio app create [PATH]`
 
@@ -278,7 +280,7 @@ DESCRIPTION
   Create a new Adobe I/O App with default parameters
 ```
 
-_See code: [src/commands/app/create.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/create.ts)_
+_See code: [src/commands/app/create.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/create.js)_
 
 ## `aio app delete`
 
@@ -296,7 +298,7 @@ DESCRIPTION
   Delete a component from an existing Adobe I/O App
 ```
 
-_See code: [src/commands/app/delete/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/index.ts)_
+_See code: [src/commands/app/delete/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/index.js)_
 
 ## `aio app delete action [ACTION-NAME]`
 
@@ -322,7 +324,7 @@ ALIASES
   $ aio app delete actions
 ```
 
-_See code: [src/commands/app/delete/action.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/action.ts)_
+_See code: [src/commands/app/delete/action.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/action.js)_
 
 ## `aio app delete ci`
 
@@ -341,7 +343,7 @@ DESCRIPTION
   Delete existing CI files
 ```
 
-_See code: [src/commands/app/delete/ci.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/ci.ts)_
+_See code: [src/commands/app/delete/ci.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/ci.js)_
 
 ## `aio app delete extension`
 
@@ -367,7 +369,7 @@ ALIASES
   $ aio app delete extensions
 ```
 
-_See code: [src/commands/app/delete/extension.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/extension.ts)_
+_See code: [src/commands/app/delete/extension.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/extension.js)_
 
 ## `aio app delete service`
 
@@ -391,7 +393,7 @@ ALIASES
   $ aio app delete services
 ```
 
-_See code: [src/commands/app/delete/service.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/service.ts)_
+_See code: [src/commands/app/delete/service.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/service.js)_
 
 ## `aio app delete web-assets`
 
@@ -410,7 +412,7 @@ DESCRIPTION
   Delete existing web assets
 ```
 
-_See code: [src/commands/app/delete/web-assets.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/web-assets.ts)_
+_See code: [src/commands/app/delete/web-assets.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/delete/web-assets.js)_
 
 ## `aio app deploy`
 
@@ -451,7 +453,7 @@ DESCRIPTION
   This will always force a rebuild unless --no-force-build is set.
 ```
 
-_See code: [src/commands/app/deploy.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/deploy.ts)_
+_See code: [src/commands/app/deploy.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/deploy.js)_
 
 ## `aio app get-url [ACTION]`
 
@@ -474,7 +476,7 @@ DESCRIPTION
   Get action URLs
 ```
 
-_See code: [src/commands/app/get-url.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/get-url.ts)_
+_See code: [src/commands/app/get-url.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/get-url.js)_
 
 ## `aio app info`
 
@@ -496,7 +498,7 @@ DESCRIPTION
   Display settings/configuration in use by an Adobe I/O App
 ```
 
-_See code: [src/commands/app/info.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/info.ts)_
+_See code: [src/commands/app/info.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/info.js)_
 
 ## `aio app init [PATH]`
 
@@ -532,7 +534,30 @@ DESCRIPTION
   Create a new Adobe I/O App
 ```
 
-_See code: [src/commands/app/init.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/init.ts)_
+_See code: [src/commands/app/init.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/init.js)_
+
+## `aio app install PATH`
+
+This command will support installing apps packaged by 'aio app pack'.
+
+```
+USAGE
+  $ aio app install PATH [-v] [--version] [-o <value>] [--tests]
+
+ARGUMENTS
+  PATH  Path to the app package to install
+
+FLAGS
+  -o, --output=<value>  [default: .] The packaged app output folder path
+  -v, --verbose         Verbose output
+  --[no-]tests          Run packaged app unit tests (e.g. aio app:test)
+  --version             Show version
+
+DESCRIPTION
+  This command will support installing apps packaged by 'aio app pack'.
+```
+
+_See code: [src/commands/app/install.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/install.js)_
 
 ## `aio app list`
 
@@ -550,7 +575,7 @@ DESCRIPTION
   List components for Adobe I/O App
 ```
 
-_See code: [src/commands/app/list/index.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/list/index.ts)_
+_See code: [src/commands/app/list/index.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/list/index.js)_
 
 ## `aio app list extension`
 
@@ -575,7 +600,7 @@ ALIASES
   $ aio app list extensions
 ```
 
-_See code: [src/commands/app/list/extension.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/list/extension.ts)_
+_See code: [src/commands/app/list/extension.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/list/extension.js)_
 
 ## `aio app logs`
 
@@ -599,7 +624,29 @@ DESCRIPTION
   Fetch logs for an Adobe I/O App
 ```
 
-_See code: [src/commands/app/logs.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/logs.ts)_
+_See code: [src/commands/app/logs.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/logs.js)_
+
+## `aio app pack [PATH]`
+
+This command will support packaging apps for redistribution.
+
+```
+USAGE
+  $ aio app pack [PATH] [-v] [--version] [-o <value>]
+
+ARGUMENTS
+  PATH  [default: .] Path to the app directory to package
+
+FLAGS
+  -o, --output=<value>  [default: dist/app.zip] The packaged app output file path
+  -v, --verbose         Verbose output
+  --version             Show version
+
+DESCRIPTION
+  This command will support packaging apps for redistribution.
+```
+
+_See code: [src/commands/app/pack.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/pack.js)_
 
 ## `aio app run`
 
@@ -622,7 +669,7 @@ DESCRIPTION
   Run an Adobe I/O App
 ```
 
-_See code: [src/commands/app/run.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/run.ts)_
+_See code: [src/commands/app/run.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/run.js)_
 
 ## `aio app test`
 
@@ -650,7 +697,7 @@ DESCRIPTION
   If the extension has a hook called 'test' in its 'ext.config.yaml', the script specified will be run instead.
 ```
 
-_See code: [src/commands/app/test.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/test.ts)_
+_See code: [src/commands/app/test.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/test.js)_
 
 ## `aio app undeploy`
 
@@ -675,7 +722,7 @@ DESCRIPTION
   Undeploys an Adobe I/O App
 ```
 
-_See code: [src/commands/app/undeploy.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/undeploy.ts)_
+_See code: [src/commands/app/undeploy.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/undeploy.js)_
 
 ## `aio app use [CONFIG_FILE_PATH]`
 
@@ -722,5 +769,5 @@ DESCRIPTION
   page in https://developer.adobe.com/console/
 ```
 
-_See code: [src/commands/app/use.ts](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/use.ts)_
+_See code: [src/commands/app/use.js](https://github.com/adobe/aio-cli-plugin-app/blob/12.0.0/src/commands/app/use.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "@adobe/generator-aio-app": "^7",
     "@adobe/generator-app-common-lib": "^2",
     "@adobe/inquirer-table-checkbox": "^2",
-    "@octokit/rest": "^19.0.11",
     "@oclif/core": "^2.11.6",
+    "@octokit/rest": "^19.0.11",
     "@parcel/core": "^2.7.0",
     "@parcel/reporter-cli": "^2.7.0",
     "ajv": "^8",
@@ -38,6 +38,7 @@
     "hyperlinker": "^1.0.0",
     "inquirer": "^8",
     "js-yaml": "^4.1.0",
+    "junk": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
     "node-abort-controller": "^3.1.1",
     "node-fetch": "^2.6.7",
@@ -48,13 +49,12 @@
     "term-size": "^2.2.1",
     "unzipper": "^0.10.11",
     "upath": "^2",
-    "junk": "^3.1.0",
     "which": "^4.0.0",
     "yeoman-environment": "^3.2.0"
   },
   "devDependencies": {
     "@adobe/aio-lib-test-proxy": "^2",
-    "@adobe/eslint-config-aio-lib-config": "^2.0.2",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "@types/jest": "^29",
     "babel-runtime": "^6.26.0",
     "core-js": "^3",
@@ -70,8 +70,7 @@
     "jest": "^29.5.0",
     "nock": "^13.2.9",
     "oclif": "^3.2.0",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^5.1.6"
+    "stdout-stderr": "^0.1.9"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #759

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
