### PR TITLE
fix: pack throws getting api-mesh

### DIFF
--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -166,15 +166,18 @@ class Pack extends BaseCommand {
     if (command) {
       try {
         this.spinner.start('Getting api-mesh config...')
-        const { stdout } = await execa('aio', ['api-mesh', 'get'], { cwd: process.cwd() })
-        // until we get the --json flag, we parse the output
-        const idx = stdout.indexOf('{')
-        meshConfig = JSON.parse(stdout.substring(idx)).meshConfig
+        const { stdout, stderr } = await execa('aio', ['api-mesh', 'get', '--json'], { cwd: process.cwd() })
+
+        if (stderr) {
+          throw new Error(stderr)
+        }
+
+        meshConfig = JSON.parse(stdout).meshConfig
         aioLogger.debug(`api-mesh:get - ${JSON.stringify(meshConfig, null, 2)}`)
         this.spinner.succeed('Got api-mesh config')
       } catch (err) {
         // Ignore error if no mesh found, otherwise throw
-        if (err?.stderr.includes('Error: Unable to get mesh config. No mesh found for Org')) {
+        if (err?.message.includes('Error: Unable to get mesh config. No mesh found for Org')) {
           aioLogger.debug('No api-mesh config found')
         } else {
           console.error(err)

--- a/test/__fixtures__/pack/3.api-mesh.get.json
+++ b/test/__fixtures__/pack/3.api-mesh.get.json
@@ -1,7 +1,4 @@
-Selected organization: My Org
-Selected project: My Project
-Select workspace: Stage
-Successfully retrieved mesh {
+{
   "lastUpdated": "2023-03-02T09:58:23.896Z",
   "meshConfig": {
     "sources": [


### PR DESCRIPTION
## Description

Start using the `--json` flag when getting api-mesh during `aio app pack` and throw any resulting stderr

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-app/issues/773

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally linked plugin, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
