### PR TITLE
Log most recent error when OpenWhisk readiness times out

### DIFF
--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -531,13 +531,14 @@ test('waitForOpenWhiskReadiness timeout', async () => {
   const period = 5000
   const timeout = 5000
   const endTime = Date.now() - 1000 // ends now
+  const status = 'FAIL'
 
   const waitFunc = jest.fn((_period) => {
     expect(_period).toEqual(period)
   })
-  const result = appHelper.waitForOpenWhiskReadiness(host, endTime, period, timeout, waitFunc)
+  const result = appHelper.waitForOpenWhiskReadiness(host, endTime, period, timeout, status, waitFunc)
 
-  await expect(result).rejects.toEqual(new Error(`local openwhisk stack startup timed out: ${timeout}ms`))
+  await expect(result).rejects.toEqual(new Error(`local openwhisk stack startup timed out after ${timeout}ms due to ${status}`))
   expect(mockFetch).toHaveBeenCalledTimes(0)
   expect(waitFunc).toHaveBeenCalledTimes(0)
 })
@@ -547,6 +548,7 @@ test('waitForOpenWhiskReadiness (fail, retry, then success)', async () => {
   const period = 5000
   const timeout = 5000
   const endTime = Date.now() + 5000
+  const status = null
 
   const waitFunc = jest.fn((_period) => {
     expect(_period).toEqual(period)
@@ -555,7 +557,7 @@ test('waitForOpenWhiskReadiness (fail, retry, then success)', async () => {
     .mockRejectedValueOnce(new Error('some error')) // first fail (fetch exception)
     .mockRejectedValueOnce({ ok: false }) // second fail (response not ok)
     .mockResolvedValue({ ok: true }) // finally success
-  const result = appHelper.waitForOpenWhiskReadiness(host, endTime, period, timeout, waitFunc)
+  const result = appHelper.waitForOpenWhiskReadiness(host, endTime, period, timeout, status, waitFunc)
 
   await expect(result).resolves.not.toBeDefined()
   expect(mockFetch).toHaveBeenCalledTimes(3)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`waitForOpenWhiskReadiness` timeout now include most recent error in throw, e.g. `FetchError: request to http://localhost:3233/api/v1 failed, reason: connect ECONNREFUSED ::1:3233`

## Motivation and Context

Subsequent OpenWhisk local runs keep timing out after initial runs were working. I had to debug in this way to understand why.

OT: createFetch cannot access local port suggesting OW is not running, but it is and my browser can access. Definitely some unrelated bug.

## How Has This Been Tested?

- unit test
- monkeypatch manual test:

```sh
Error: local openwhisk stack startup timed out after 60000ms due to FetchError: request to http://localhost:3233/api/v1 failed, reason: connect ECONNREFUSED ::1:3233
    at Object.error (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli-plugin-app/node_modules/@oclif/core/lib/errors/index.js:27:15)
    at Run.error (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli-plugin-app/node_modules/@oclif/core/lib/command.js:139:23)
    at Run.catch (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli-plugin-app/src/BaseCommand.js:38:10)
    at async Run._run (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli-plugin-app/node_modules/@oclif/core/lib/command.js:121:13)
    at async Config.runCommand (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli/node_modules/@oclif/core/lib/config/config.js:329:25)
    at async run (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli/node_modules/@oclif/core/lib/main.js:89:16)
    at async AIOCommand.run (/Users/hgpa/hgpa/git/git.corp.adobe.com/wcms/seotech/node_modules/@adobe/aio-cli/src/index.js:30:12)
?2 seotech (MWPW-142722) %  
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
