### PR TITLE
feat: inherit secrets for node.js CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,4 +11,5 @@ on:
 
 jobs:
   build:
-    uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@allow-ci-no-codecov
+    uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@main
+    secrets: inherit

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   build:
-    uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@main
+    uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@allow-ci-no-codecov


### PR DESCRIPTION
## Description

~_Note: Using this pr as a test bed for the branch that does not require the CODECOV_TOKEN to see if node ci still runs_~ it works 🥳 

Inherit secrets in the Node.JS CI workflow so we can upload coverage using the codecov@v4 action in the re-usable workflow.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
