### PR TITLE
fix: incorrect logic for flag --confirm-new-workspace in command aio app init

### DIFF
--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -322,7 +322,7 @@ class InitCommand extends TemplatesCommand {
     const workspaces = await consoleCLI.getWorkspaces(org.id, project.id)
     let workspace = workspaces.find(w => w.name.toLowerCase() === workspaceName.toLowerCase())
     if (!workspace) {
-      if (!flags['confirm-new-workspace']) {
+      if (flags['confirm-new-workspace']) {
         const shouldNewWorkspace = await consoleCLI.prompt.promptConfirm(`Workspace '${workspaceName}' does not exist \n > Do you wish to create a new workspace?`)
         if (!shouldNewWorkspace) {
           this.error(`Workspace '${workspaceName}' does not exist and creation aborted`)


### PR DESCRIPTION
fixes #792 

## How Has This Been Tested?

- npm test
- manual test after local link of the plugin

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
