### PR TITLE
upcase all keys before storing in .env

### DIFF
--- a/src/lib/import-helper.js
+++ b/src/lib/import-helper.js
@@ -413,7 +413,7 @@ async function writeEnv (json, parentFolder, flags, extraEnvVars) {
 
   const data = Object
     .keys(resultObject)
-    .map(key => `${key}=${resultObject[key]}`)
+    .map(key => `${key.toUpperCase()}=${resultObject[key]}`)
     .join(EOL)
     .concat(EOL)
   aioLogger.debug(`writeEnv - data:${data}`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

[Confusing lowercase .env keys adobe/aio-cli](https://github.com/adobe/aio-cli/issues/611)

I have not updated the tests as this really just means upcasing all the fixtures and I want to be sure there are no unexpected side-effects before heavy handedly making the tests pass.


## Motivation and Context

I was confused ... I still am about this key:
`AIO_ims_contexts_Credential__in__Jesse__Is__Back__-__Stage_client__id` 

`-` is not valid in an identifier/property name, so this becomes:
( note the ticks )
```
  AIO_RUNTIME_APIHOST: 'https://adobeioruntime.net',
  'AIO_IMS_CONTEXTS_CREDENTIAL__IN__JESSE__IS__BACK__-__STAGE_CLIENT__ID': ...
``` 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
