### PR TITLE
feat: run add-vscode-config generator on app init (retooled local debugging)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@adobe/aio-lib-runtime": "^6",
     "@adobe/aio-lib-templates": "^3",
     "@adobe/aio-lib-web": "^7",
-    "@adobe/generator-aio-app": "^7",
+    "@adobe/generator-aio-app": "^8",
     "@adobe/generator-app-common-lib": "^2",
     "@adobe/inquirer-table-checkbox": "^2",
     "@oclif/core": "^2.11.6",

--- a/src/commands/app/init.js
+++ b/src/commands/app/init.js
@@ -75,7 +75,7 @@ class InitCommand extends TemplatesCommand {
 
   getInitialGenerators (flags) {
     // TODO read from config to override
-    const initialGenerators = ['base-app', 'add-ci']
+    const initialGenerators = ['base-app', 'add-ci', 'add-vscode-config']
 
     if (flags['standalone-app']) {
       initialGenerators.push('application')

--- a/test/commands/app/init.test.js
+++ b/test/commands/app/init.test.js
@@ -314,7 +314,7 @@ describe('--no-login', () => {
     await command.run()
 
     expect(command.installTemplates).toHaveBeenCalledWith(installOptions)
-    expect(command.runCodeGenerators).toHaveBeenCalledWith(['base-app', 'add-ci', 'application'], false, 'cwd', 'basic')
+    expect(command.runCodeGenerators).toHaveBeenCalledWith(['base-app', 'add-ci', 'add-vscode-config', 'application'], false, 'cwd', 'basic')
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
     expect(importHelperLib.importConfigJson).not.toHaveBeenCalled()
   })
@@ -464,7 +464,7 @@ describe('--no-login', () => {
     await command.run()
 
     expect(command.installTemplates).toHaveBeenCalledWith(installOptions)
-    expect(command.runCodeGenerators).toHaveBeenCalledWith(['base-app', 'add-ci', 'application'], true, 'cwd', 'none')
+    expect(command.runCodeGenerators).toHaveBeenCalledWith(['base-app', 'add-ci', 'add-vscode-config', 'application'], true, 'cwd', 'none')
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
     expect(importHelperLib.importConfigJson).not.toHaveBeenCalled()
   })
@@ -482,7 +482,7 @@ describe('--no-login', () => {
     await command.run()
 
     expect(command.installTemplates).toHaveBeenCalledWith(installOptions)
-    expect(command.runCodeGenerators).toHaveBeenCalledWith(['base-app', 'add-ci', 'application'], true, 'cwd', 'adobe-recommended')
+    expect(command.runCodeGenerators).toHaveBeenCalledWith(['base-app', 'add-ci', 'add-vscode-config', 'application'], true, 'cwd', 'adobe-recommended')
     expect(LibConsoleCLI.init).not.toHaveBeenCalled()
     expect(importHelperLib.importConfigJson).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
⚠️ **Note:** needs https://github.com/adobe/aio-cli-plugin-app-dev installed for debugging - this new plugin should be a core plugin in the aio-cli

## How Has This Been Tested?

- npm test
- aio app init MyApp, then running the debugger on an action (works on an app with frontend/extension, `--standalone-app` has this [issue](https://github.com/adobe/aio-cli-plugin-app-dev/issues/22))

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
