### PR TITLE
Optimize build and deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@adobe/aio-lib-core-networking": "^5",
     "@adobe/aio-lib-env": "^3",
     "@adobe/aio-lib-ims": "^7",
-    "@adobe/aio-lib-runtime": "^6",
+    "@adobe/aio-lib-runtime": "^7.0.0",
     "@adobe/aio-lib-templates": "^3",
     "@adobe/aio-lib-web": "^7",
     "@adobe/generator-aio-app": "^7",

--- a/src/commands/app/build.js
+++ b/src/commands/app/build.js
@@ -72,7 +72,7 @@ class Build extends BaseCommand {
     if (flags.actions) {
       // removed flags['force-build'] || as it is always forced at this point, we need to check to decide what to build
       // if no backend, we skip the build
-      if (config.app.hasBackend) { //  && (flags['force-build'] || !fs.existsSync(config.actions.dist))) {
+      if (config.app.hasBackend) {
         try {
           let builtList = []
           const script = await runInProcess(config.hooks['build-actions'], config)
@@ -96,7 +96,7 @@ class Build extends BaseCommand {
           throw err
         }
       } else {
-        spinner.info(`no backend or a build already exists, skipping action build for '${name}'`)
+        spinner.info(`no backend, skipping action build for '${name}'`)
       }
     }
     if (flags['web-assets']) {
@@ -130,7 +130,7 @@ class Build extends BaseCommand {
         }
       } else {
         // TODO: specify which ... keep this useful
-        spinner.info(`no frontend or a build already exists, skipping frontend build for '${name}'`)
+        spinner.info(chalk.green(`No frontend or a build already exists, skipping frontend build for '${name}'`))
       }
     }
     try {

--- a/src/commands/app/build.js
+++ b/src/commands/app/build.js
@@ -143,7 +143,8 @@ class Build extends BaseCommand {
 
 Build.description = `Build an Adobe I/O App
 
-This will always force a rebuild unless --no-force-build is set.
+Build the actions and web assets for an Adobe I/O App. Build is optimized to only build what is necessary.
+Use the --force-build flag to force a build even if one already exists.
 `
 
 Build.flags = {

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -319,7 +319,7 @@ Deploy.flags = {
   'force-build': Flags.boolean({
     description: '[default: true] Force a build even if one already exists',
     exclusive: ['no-build'], // no-build
-    default: true,
+    default: false,
     allowNo: true
   }),
   'content-hash': Flags.boolean({

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -287,9 +287,13 @@ class Deploy extends BuildCommand {
   }
 }
 
-Deploy.description = `Build and deploy an Adobe I/O App
+Deploy.description = `Deploy an Adobe I/O App
 
-This will always force a rebuild unless --no-force-build is set.
+Deploys the actions and web assets for an Adobe I/O App.
+This will also build any changed actions or web assets before deploying.
+Use the --force-build flag to force a build even if one already exists.
+Deploy is optimized to only deploy what is necessary. Be aware that deploying actions will overwrite any previous deployments.
+Use the --force-deploy flag to force deploy changes, regardless of production Workspace being published in Exchange.
 `
 
 Deploy.flags = {

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -172,7 +172,7 @@ class Deploy extends BuildCommand {
               // output should be "Error : <plugin-name> : <error-message>\n" for each failure
               this.error(hookResults.failures.map(f => `${f.plugin.name} : ${f.error.message}`).join('\nError: '), { exit: 1 })
             }
-            deployedRuntimeEntities = await rtLib.deployActions(config, { filterEntities }, onProgress)
+            deployedRuntimeEntities = await rtLib.deployActions(config, { filterEntities, useForce: flags['force-deploy'] }, onProgress)
           }
 
           if (deployedRuntimeEntities.actions && deployedRuntimeEntities.actions.length > 0) {
@@ -181,7 +181,7 @@ class Deploy extends BuildCommand {
             if (script) {
               spinner.fail(chalk.green(`deploy-actions skipped by hook '${name}'`))
             } else {
-              spinner.fail(chalk.green(`No actions deployed for '${name}'`))
+              spinner.info(chalk.green(`No actions deployed for '${name}'`))
             }
           }
         } catch (err) {

--- a/src/commands/app/run.js
+++ b/src/commands/app/run.js
@@ -108,6 +108,9 @@ class Run extends BaseCommand {
     }
 
     const verboseOutput = flags.verbose || flags.local || headlessApp
+    // we should evaluate this, a lot of output just disappears in the spinner text and
+    // using verbose dumps ALL of parcel's output, so this become unreadable
+    // we need a middle ground. -jm
     const onProgress = !verboseOutput
       ? info => {
         spinner.text = info

--- a/src/lib/actions-watcher.js
+++ b/src/lib/actions-watcher.js
@@ -38,7 +38,7 @@ const deployActions = require('./deploy-actions')
 module.exports = async (watcherOptions) => {
   const { config, log } = watcherOptions
 
-  log(`watching action files at ${config.actions.src}...`)
+  log(`watching action files at ${config.actions.src} ...`)
   const watcher = chokidar.watch(config.actions.src)
 
   watcher.on('change', createChangeHandler({ ...watcherOptions, watcher }))
@@ -91,6 +91,8 @@ function createChangeHandler (watcherOptions) {
     try {
       aioLogger.debug(`${filePath} has changed. Redeploying actions.`)
       const filterActions = getActionNameFromPath(filePath, watcherOptions)
+      // this is happening, but its not showing up because verbose is usually off
+      // this might be more important and worthy of signalling to the user
       if (!filterActions.length) {
         log('  -> A non-action file was changed, restart is required to deploy...')
       } else {
@@ -119,6 +121,13 @@ function createChangeHandler (watcherOptions) {
  * @returns {Array<string>}  All of the actions which match the modified path
  */
 function getActionNameFromPath (filePath, watcherOptions) {
+  // note: this check only happens during aio app run
+  // before the watcher is started, all actions are built and deployed and hashes updated
+  // this code is missing 2 cases:
+  // 1. if the action is a folder with a package.json and the changed file is in the folder
+  // 2. if the changed file is in the folder with the action, but not the action file itself
+  // we need to be careful with these cases, because we could cause a recursive loop
+  // for now we continue to error on the cautious side, and output a message suggesting a restart
   const actionNames = []
   const unixFilePath = upath.toUnix(filePath)
   const { config } = watcherOptions
@@ -126,7 +135,10 @@ function getActionNameFromPath (filePath, watcherOptions) {
     if (pkg.actions) {
       Object.entries(pkg.actions).forEach(([actionName, action]) => {
         const unixActionFunction = upath.toUnix(action.function)
-        if (unixActionFunction.includes(unixFilePath)) {
+        // since action could be a folder, and changed file could be in the folder
+        // we need to compare both ways
+        // there are 2 additional cases listed above
+        if (unixActionFunction.includes(unixFilePath) || unixFilePath.includes(unixActionFunction)) {
           actionNames.push(actionName)
         }
       })

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -83,7 +83,6 @@ async function runDev (config, dataDir, options = {}, log = () => {}, inprocHook
       // build and deploy actions
       log('building actions..')
       await buildActions(devConfig, null, false /* force build */)
-      console.log('log = ', log('boo'))
       const { cleanup: watcherCleanup } = await actionsWatcher({ config: devConfig, isLocal, log, inprocHook })
       cleanup.add(() => watcherCleanup(), 'stopping action watcher...')
     }

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -82,7 +82,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}, inprocHook
 
       // build and deploy actions
       log('building actions..')
-      await buildActions(devConfig, null, true /* force build */)
+      await buildActions(devConfig, null, false /* force build */)
 
       const { cleanup: watcherCleanup } = await actionsWatcher({ config: devConfig, isLocal, log, inprocHook })
       cleanup.add(() => watcherCleanup(), 'stopping action watcher...')

--- a/src/lib/run-dev.js
+++ b/src/lib/run-dev.js
@@ -83,7 +83,7 @@ async function runDev (config, dataDir, options = {}, log = () => {}, inprocHook
       // build and deploy actions
       log('building actions..')
       await buildActions(devConfig, null, false /* force build */)
-
+      console.log('log = ', log('boo'))
       const { cleanup: watcherCleanup } = await actionsWatcher({ config: devConfig, isLocal, log, inprocHook })
       cleanup.add(() => watcherCleanup(), 'stopping action watcher...')
     }
@@ -152,10 +152,16 @@ async function runDev (config, dataDir, options = {}, log = () => {}, inprocHook
       devConfig.app.hasFrontend = false
     }
 
-    log('setting up vscode debug configuration files...')
-    const vscodeConfig = vscode(devConfig)
-    await vscodeConfig.update({ frontEndUrl })
-    cleanup.add(() => vscodeConfig.cleanup(), 'cleaning up vscode debug configuration files...')
+    // todo: remove vscode config swapping, dev command uses a persistent file so we don't need this.
+    // also there was a latent issue with projects that defined an action src as a folder with an index.js file.
+    // it looks explicitly for package.json and fails if it does not find it.
+    // regarless, we don't need it, and when we actually remove --local we can be rid of this.
+    if (isLocal) {
+      log('setting up vscode debug configuration files...')
+      const vscodeConfig = vscode(devConfig)
+      await vscodeConfig.update({ frontEndUrl })
+      cleanup.add(() => vscodeConfig.cleanup(), 'cleaning up vscode debug configuration files...')
+    }
 
     // automatically fetch logs if there are actions
     if (config.app.hasBackend && fetchLogs) {

--- a/test/commands/app/build.test.js
+++ b/test/commands/app/build.test.js
@@ -182,7 +182,7 @@ test('flags', async () => {
 
   expect(typeof TheCommand.flags['force-build']).toBe('object')
   expect(typeof TheCommand.flags['force-build'].description).toBe('string')
-  expect(TheCommand.flags['force-build'].default).toEqual(true)
+  expect(TheCommand.flags['force-build'].default).toEqual(false)
   expect(TheCommand.flags['force-build'].allowNo).toEqual(true)
 
   expect(typeof TheCommand.flags['content-hash']).toBe('object')
@@ -285,6 +285,7 @@ describe('run', () => {
   })
 
   test('build & deploy an App with no force-build but build exists', async () => {
+    // build actions is now called so it can verify if the src has changed since the last build
     command.appConfig.actions.dist = 'actions'
     command.appConfig.web.distProd = 'dist'
     command.getAppExtConfigs.mockResolvedValueOnce(createAppConfig(command.appConfig))
@@ -293,7 +294,7 @@ describe('run', () => {
     mockFS.existsSync.mockReturnValue(true)
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
-    expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(0)
+    expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(0)
   })
 
@@ -326,7 +327,7 @@ describe('run', () => {
     expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Built 3 action(s) for \'application\''))
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockRuntimeLib.buildActions).toHaveBeenCalledTimes(1)
-    expect(mockRuntimeLib.buildActions).toHaveBeenCalledWith(appConfig.application, ['a', 'b', 'c'], true)
+    expect(mockRuntimeLib.buildActions).toHaveBeenCalledWith(appConfig.application, ['a', 'b', 'c'], false)
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(0)
   })
 
@@ -344,9 +345,9 @@ describe('run', () => {
 
   test('build & deploy with --no-actions', async () => {
     command.getAppExtConfigs.mockResolvedValueOnce(createAppConfig(command.appConfig))
-
-    command.argv = ['--no-actions']
+    command.argv = ['--no-actions', '--force-build']
     mockFS.existsSync.mockReturnValue(true)
+
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)
     expect(mockWebLib.bundle).toHaveBeenCalledTimes(1)

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -194,7 +194,7 @@ test('flags', async () => {
 
   expect(typeof TheCommand.flags['force-build']).toBe('object')
   expect(typeof TheCommand.flags['force-build'].description).toBe('string')
-  expect(TheCommand.flags['force-build'].default).toEqual(true)
+  expect(TheCommand.flags['force-build'].default).toEqual(false)
   expect(TheCommand.flags['force-build'].allowNo).toEqual(true)
 
   expect(typeof TheCommand.flags['content-hash']).toBe('object')
@@ -293,7 +293,10 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, verbose: true }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, verbose: true }),
+      expect.anything())
   })
 
   test('build & deploy --no-web-assets', async () => {
@@ -306,7 +309,10 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, 'web-assets': false }),
+      expect.anything())
   })
 
   test('build & deploy only one action using --action (workspace: Production)', async () => {
@@ -347,7 +353,10 @@ describe('run', () => {
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
     expect(mockLibConsoleCLI.getApplicationExtensions).toHaveBeenCalledTimes(0)
 
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false, action: ['a', 'b', 'c'] }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, 'web-assets': false, action: ['a', 'b', 'c'] }),
+      expect.anything())
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(appConfig.application, {
       filterEntities: { actions: ['a', 'b', 'c'] }
     },
@@ -365,7 +374,10 @@ describe('run', () => {
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
 
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false, action: ['c'] }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, 'web-assets': false, action: ['c'] }),
+      expect.anything())
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(appConfig.application, {
       filterEntities: { actions: ['c'] }
     },
@@ -384,7 +396,10 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, 'web-assets': false }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, 'web-assets': false }),
+      expect.anything())
   })
 
   test('build & deploy actions with no actions folder but with a manifest', async () => {
@@ -408,7 +423,10 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, actions: false }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, actions: false }),
+      expect.anything())
   })
 
   test('build & deploy with --no-actions with no static folder', async () => {
@@ -423,7 +441,10 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(0)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true, actions: false }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false, actions: false }),
+      expect.anything())
   })
 
   test('build & deploy with no manifest.yml', async () => {
@@ -437,7 +458,10 @@ describe('run', () => {
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(0)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
-    expect(command.buildOneExt).toHaveBeenCalledWith('application', appConfig.application, expect.objectContaining({ 'force-build': true }), expect.anything())
+    expect(command.buildOneExt).toHaveBeenCalledWith('application',
+      appConfig.application,
+      expect.objectContaining({ 'force-build': false }),
+      expect.anything())
   })
 
   test('--no-build', async () => {

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -358,7 +358,8 @@ describe('run', () => {
       expect.objectContaining({ 'force-build': false, 'web-assets': false, action: ['a', 'b', 'c'] }),
       expect.anything())
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(appConfig.application, {
-      filterEntities: { actions: ['a', 'b', 'c'] }
+      filterEntities: { actions: ['a', 'b', 'c'] },
+      useForce: false
     },
     expect.any(Function))
   })
@@ -379,7 +380,8 @@ describe('run', () => {
       expect.objectContaining({ 'force-build': false, 'web-assets': false, action: ['c'] }),
       expect.anything())
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(appConfig.application, {
-      filterEntities: { actions: ['c'] }
+      filterEntities: { actions: ['c'] },
+      useForce: false
     },
     expect.any(Function))
   })
@@ -924,6 +926,7 @@ describe('run', () => {
     expect(mockLibConsoleCLI.getApplicationExtensions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
+    expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ useForce: true }), expect.any(Function))
     expect(mockLibConsoleCLI.updateExtensionPoints).toHaveBeenCalledTimes(0)
     expect(mockLibConsoleCLI.updateExtensionPointsWithoutOverwrites).toHaveBeenCalledTimes(0)
   })
@@ -952,6 +955,7 @@ describe('run', () => {
     expect(mockLibConsoleCLI.getApplicationExtensions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
+    expect(mockRuntimeLib.deployActions).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ useForce: true }), expect.any(Function))
     expect(mockLibConsoleCLI.updateExtensionPoints).toHaveBeenCalledTimes(0)
     expect(mockLibConsoleCLI.updateExtensionPointsWithoutOverwrites).toHaveBeenCalledTimes(0)
   })

--- a/test/commands/lib/run-dev.test.js
+++ b/test/commands/lib/run-dev.test.js
@@ -409,11 +409,13 @@ test('isLocal false, build-static hook set, serve-static hook not set)', async (
   expect(actionsWatcher).toHaveBeenCalled()
 })
 
-test('runDev always force builds', async () => {
+test('runDev does not always force builds', async () => {
   const config = cloneDeep(createAppConfig().application)
 
   await runDev(config, DATA_DIR, { isLocal: false })
 
   expect(buildActions).toHaveBeenCalled()
-  expect(buildActions).toHaveBeenCalledWith(expect.any(Object) /* config */, null /* filterActions */, true /* forceBuild */)
+  expect(buildActions).toHaveBeenCalledWith(expect.any(Object) /* config */,
+    null /* filterActions */,
+    false /* forceBuild */)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This changes the default for flag --force-build to false
RuntimeLib will include additional checks to not build actions it has already built, and not deploy actions already deployed.  In order for users to see these benefits, the defaults are to use the optimized workflow and reduce time to build/deploy/run

If an action has changed, it will be built during app build/deploy/run
If an action has changed ( or action inputs including from $env or action descriptors ) it will be deployed during app deploy/run

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
