### PR TITLE
fix: deploy - output the error from the audit log api if `--verbose` is set

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -112,6 +112,9 @@ class Deploy extends BuildCommand {
               await sendAuditLogs(cliDetails.accessToken, assetDeployedLogEvent, cliDetails.env)
             } catch (error) {
               this.warn('Error: Audit Log Service Error: Failed to send audit log event for deployment.')
+              if (flags.verbose) {
+                this.warn(error.message)
+              }
             }
           }
         }

--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -111,8 +111,8 @@ class Deploy extends BuildCommand {
               // only send logs in case of web-assets deployment
               await sendAuditLogs(cliDetails.accessToken, assetDeployedLogEvent, cliDetails.env)
             } catch (error) {
-              this.warn('Error: Audit Log Service Error: Failed to send audit log event for deployment.')
               if (flags.verbose) {
+                this.warn('Error: Audit Log Service Error: Failed to send audit log event for deployment.')
                 this.warn(error.message)
               }
             }


### PR DESCRIPTION
## How Has This Been Tested?

- local link the plugin
- try to deploy with `--verbose`, it should error in the audit log api (there is a bug/service issue currently), and show the exception message

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
