### PR TITLE
fix: ACNA-3828 - `aio app undeploy` should remove the build cache

### DIFF
--- a/src/commands/app/undeploy.js
+++ b/src/commands/app/undeploy.js
@@ -110,8 +110,15 @@ class Undeploy extends BaseCommand {
       // delegate to top handler
       throw error
     }
+
+    const command = await this.config.findCommand('app:clean')
+    if (command) {
+      this.log('running app:clean command')
+      await this.config.runCommand('app:clean')
+    }
+
     // final message
-    this.log(chalk.green(chalk.bold('Undeploy done !')))
+    this.log(chalk.green(chalk.bold('Undeploy done!')))
   }
 
   async undeployOneExt (extName, config, flags, spinner) {


### PR DESCRIPTION
closes #830

## How Has This Been Tested?

- local link this app plugin PR branch
- `aio app deploy` then
- `aio app undeploy` (should run `aio app clean`)
- `aio app deploy` after should not error (the usual workaround was to `rm -rf dist`)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
