### PR TITLE
fix: audit log event-post API update

### DIFF
--- a/src/lib/audit-logger.js
+++ b/src/lib/audit-logger.js
@@ -116,15 +116,9 @@ function getAuditLogEvent ({ cliCommandFlags, operation, appInfo }) {
     throw new Error(`Invalid operation: ${operation}`)
   }
   const orgId = project.org.id
-  const projectId = project.id
-  const workspaceId = project.workspace.id
-  const workspaceName = project.workspace.name
 
   const logEvent = {
     orgId,
-    projectId,
-    workspaceId,
-    workspaceName,
     operation,
     objectRef: appInfo.name,
     objectRev: appInfo.version,

--- a/test/commands/lib/audit-logger.test.js
+++ b/test/commands/lib/audit-logger.test.js
@@ -53,9 +53,6 @@ describe('audit-logger', () => {
 
       expect(event).toEqual({
         orgId: 'fake-org-id',
-        projectId: 'fake-project-id',
-        workspaceId: 'fake-workspace-id',
-        workspaceName: 'fake-workspace',
         operation: OPERATIONS.AB_APP_DEPLOY,
         objectRef: 'test-app',
         objectRev: '1.0.0',
@@ -77,9 +74,6 @@ describe('audit-logger', () => {
 
       expect(event).toEqual({
         orgId: 'fake-org-id',
-        projectId: 'fake-project-id',
-        workspaceId: 'fake-workspace-id',
-        workspaceName: 'fake-workspace',
         operation: OPERATIONS.AB_APP_UNDEPLOY,
         objectRef: 'test-app',
         objectRev: '1.0.0',


### PR DESCRIPTION
## Description

Needs Deploy Service change in ACNA-3885.

## Motivation and Context

- Audit Log `event-post` API change.
- We don't need to pass in projectId, workspaceId and workspaceName - this will be retrieved by the access token check for the namespace.
- passing in the three parameters to the event is still fine for backwards compability, but they will be overridden

## How Has This Been Tested?

- `aio plugins link .` this PR branch
- run a local version of the Deploy Service (ACNA-3885 PR branch), set `AIO_DEPLOY_SERVICE_URL` to `http://localhost:3000`
- do an `aio app deploy`
 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
