### PR TITLE
fix: ACNA-3864 - action URLs are output with deploy service URL

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -504,7 +504,49 @@ function getFilesCountWithExtension (directory) {
   return log
 }
 
+/**
+ * Rewrites action URLs in deployed runtime entities using URLs from the manifest configuration.
+ *
+ * This function takes deployed runtime entities and updates the URL property of each action
+ * with the corresponding URL from the runtime manifest configuration. It creates a deep copy
+ * of the entities to avoid mutating the original object.
+ *
+ * @param {object} params - Parameters object
+ * @param {object} params.entities - The deployed runtime entities object
+ * @param {object} params.config - The application configuration object containing runtime manifest
+ * @returns {Promise<object>} A promise that resolves to a deep copy of the entities object with updated action URLs
+ * @example
+ * const entities = {
+ *   actions: [
+ *     { name: 'my-action', url: 'old-url' },
+ *     { name: 'another-action', url: 'another-old-url' }
+ *   ]
+ * }
+ * const config = {
+ *   actions: { devRemote: false },
+ *   // ... other config properties
+ * }
+ *
+ * const rewrittenEntities = await rewriteActionUrlInEntities({ entities, config })
+ * // rewrittenEntities.actions will have updated URLs from the manifest
+ */
+async function rewriteActionUrlInEntities ({ entities, config }) {
+  const actionUrlsFromManifest = RuntimeLib.utils.getActionUrls(config, config.actions.devRemote)
+  const rewrittenEntities = structuredClone(entities)
+
+  rewrittenEntities.actions = rewrittenEntities.actions?.map(action => {
+    const retAction = structuredClone(action)
+    const url = actionUrlsFromManifest[action.name]
+    if (url) {
+      retAction.url = url
+    }
+    return retAction
+  })
+  return rewrittenEntities
+}
+
 module.exports = {
+  rewriteActionUrlInEntities,
   getObjectValue,
   getObjectProp,
   createWebExportFilter,

--- a/src/lib/auth-helper.js
+++ b/src/lib/auth-helper.js
@@ -64,7 +64,8 @@ const bearerAuthHandler = {
   }
 }
 
-const setRuntimeApiHostAndAuthHandler = (config) => {
+const setRuntimeApiHostAndAuthHandler = (_config) => {
+  const config = structuredClone(_config)
   const aioConfig = (config && 'runtime' in config) ? config : null
   if (aioConfig) {
     const apiEndpoint = process.env.AIO_DEPLOY_SERVICE_URL ?? defaultDeployServiceUrl

--- a/test/commands/app/config/get/log-forwarding.test.js
+++ b/test/commands/app/config/get/log-forwarding.test.js
@@ -52,7 +52,13 @@ test('get log forwarding settings (expect init to be passed a config)', async ()
   lf.getServerConfig.mockResolvedValue(serverConfig)
 
   await command.run()
-  expect(LogForwarding.init).toHaveBeenCalledWith(command.appConfig.aio)
+  // config should be deploy service settings
+  const modifiedConfig = structuredClone(command.appConfig.aio)
+  modifiedConfig.runtime.apihost = 'https://deploy-service.app-builder.adp.adobe.io/runtime'
+  modifiedConfig.runtime.auth_handler = {
+    getAuthHeader: expect.any(Function)
+  }
+  expect(LogForwarding.init).toHaveBeenCalledWith(modifiedConfig)
 })
 
 test('get log forwarding settings (local and server are the same)', async () => {

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -167,6 +167,7 @@ beforeEach(() => {
   helpers.buildExtensionPointPayloadWoMetadata.mockReset()
   helpers.buildExcShellViewExtensionMetadata.mockReset()
   helpers.createWebExportFilter.mockReset()
+  helpers.rewriteActionUrlInEntities.mockReset()
   mockLogForwarding.isLocalConfigChanged.mockReset()
   mockLogForwarding.getLocalConfigWithSecrets.mockReset()
   mockLogForwarding.updateServerConfig.mockReset()
@@ -183,6 +184,11 @@ beforeEach(() => {
       '1 HTML page(s)'
     ]
   })
+
+  helpers.rewriteActionUrlInEntities.mockImplementation(async ({ entities }) => {
+    return entities
+  })
+
   authHelper.setRuntimeApiHostAndAuthHandler.mockImplementation((aioConfig) => aioConfig)
   authHelper.getAccessToken.mockImplementation(() => {
     return {


### PR DESCRIPTION
closes #871 

## How Has This Been Tested?

- npm test
- `aio app clean && aio app deploy` on a project with app plugin linked master branch code - note the action urls printed out to the log

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
