### PR TITLE
fix: ACNA-3953 - activity logs not showing for extensions

### DIFF
--- a/src/commands/app/deploy.js
+++ b/src/commands/app/deploy.js
@@ -58,7 +58,7 @@ class Deploy extends BuildCommand {
 
     try {
       const { aio: aioConfig, packagejson: packageJson } = await this.getFullConfig()
-      const cliDetails = await getAccessToken({ useCachedToken: flags.publish })
+      const cliDetails = await getAccessToken({ useCachedToken: !flags.publish })
       const appInfo = {
         name: packageJson.name,
         version: packageJson.version,

--- a/src/commands/app/undeploy.js
+++ b/src/commands/app/undeploy.js
@@ -52,7 +52,7 @@ class Undeploy extends BaseCommand {
     const spinner = ora()
     try {
       const { aio: aioConfig, packagejson: packageJson } = await this.getFullConfig()
-      const cliDetails = await getAccessToken({ useCachedToken: flags.unpublish })
+      const cliDetails = await getAccessToken({ useCachedToken: !flags.unpublish })
       const appInfo = {
         name: packageJson.name,
         version: packageJson.version,

--- a/src/lib/auth-helper.js
+++ b/src/lib/auth-helper.js
@@ -47,8 +47,8 @@ async function getAccessToken ({ useCachedToken = false } = {}) {
 
   let accessToken = null
   if (useCachedToken) {
-    const contextConfig = await context.get(contextName)
-    accessToken = contextConfig?.access_token?.token
+    const { data } = await context.get(contextName)
+    accessToken = data?.access_token?.token
   } else {
     accessToken = await getToken(contextName)
   }

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -15,6 +15,8 @@ const BaseCommand = require('../../../src/BaseCommand')
 const cloneDeep = require('lodash.clonedeep')
 const dataMocks = require('../../data-mocks/config-loader')
 const helpersActual = jest.requireActual('../../../src/lib/app-helper.js')
+const authHelpersActual = jest.requireActual('../../../src/lib/auth-helper')
+
 const open = require('open')
 const mockBundleFunc = jest.fn()
 
@@ -394,6 +396,8 @@ describe('run', () => {
   })
 
   test('deploy does not require logged in user with --no-publish (workspace: Production)', async () => {
+    authHelper.getAccessToken.mockImplementation(authHelpersActual.getAccessToken)
+
     command.getAppExtConfigs.mockResolvedValueOnce(createAppConfig(command.appConfig, 'exc'))
     mockGetExtensionPointsRetractedApp() // not published
     command.getFullConfig.mockResolvedValue({
@@ -420,6 +424,9 @@ describe('run', () => {
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.buildOneExt).toHaveBeenCalledTimes(1)
     expect(mockLibConsoleCLI.getApplicationExtensions).not.toHaveBeenCalled()
+
+    expect(auditLogger.sendAppDeployAuditLog).toHaveBeenCalledTimes(0)
+    expect(auditLogger.sendAppAssetsDeployedAuditLog).toHaveBeenCalledTimes(0)
   })
 
   test('build & deploy only some actions using --action', async () => {

--- a/test/commands/lib/auth-helper.test.js
+++ b/test/commands/lib/auth-helper.test.js
@@ -44,7 +44,7 @@ describe('getAccessToken', () => {
   test('should use cached token when requested', async () => {
     const mockToken = 'cached-token'
     const mockEnv = 'prod'
-    const mockContext = { access_token: { token: mockToken } }
+    const mockContext = { data: { access_token: { token: mockToken } } }
     getCliEnv.mockReturnValue(mockEnv)
     context.getCurrent.mockResolvedValue(CLI)
     context.get.mockResolvedValue(mockContext)


### PR DESCRIPTION
## Description

https://jira.corp.adobe.com/browse/ACNA-3953

Activity logs for extensions were not showing up:
1. start of deploy
2. start of undeploy
3. web assets deployed
4. web assets undeployed

For standalone apps, the activity logs were fine.

## How Has This Been Tested?

- `aio app deploy` for a project with an extension, e.g Experience Cloud Shell extension
- `aio app deploy` for a standalone project (--stand-alone)
- `aio app deploy` with a technical account credential
- All relevant logs including the missing ones should show up in the project's Activity Log

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
