### PR TITLE
fix: update aio-lib-runtime version to explicit 7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@adobe/aio-lib-core-networking": "^5",
     "@adobe/aio-lib-env": "^3",
     "@adobe/aio-lib-ims": "^7",
-    "@adobe/aio-lib-runtime": "^7.1.2",
+    "@adobe/aio-lib-runtime": "^7.1.3",
     "@adobe/aio-lib-templates": "^3",
     "@adobe/aio-lib-web": "^7",
     "@adobe/generator-aio-app": "^9",


### PR DESCRIPTION
The version has an important bug fix.

This depends on https://github.com/adobe/aio-lib-runtime/pull/215 being merged and released as 7.1.3, thus the CI checks will fail until then.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
