### PR TITLE
CEXT-5618: Use @adobe/aio-lib-db for database provisioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@adobe/aio-lib-core-config": "^5",
     "@adobe/aio-lib-core-logging": "^3",
     "@adobe/aio-lib-core-networking": "^5",
+    "@adobe/aio-lib-db": "^0.1.0-beta.4",
     "@adobe/aio-lib-env": "^3",
     "@adobe/aio-lib-ims": "^7",
     "@adobe/aio-lib-runtime": "^7.1.3",

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -40,5 +40,16 @@ module.exports = {
   EXTENSIONS_CONFIG_KEY: 'extensions',
   // Adding tracking file constants
   LAST_BUILT_ACTIONS_FILENAME: 'last-built-actions.json',
-  LAST_DEPLOYED_ACTIONS_FILENAME: 'last-deployed-actions.json'
+  LAST_DEPLOYED_ACTIONS_FILENAME: 'last-deployed-actions.json',
+  // Database constants
+  DB_STATUS: {
+    PROVISIONED: 'PROVISIONED',
+    REQUESTED: 'REQUESTED',
+    PROCESSING: 'PROCESSING',
+    FAILED: 'FAILED',
+    REJECTED: 'REJECTED',
+    NOT_PROVISIONED: 'NOT_PROVISIONED',
+    DELETED: 'DELETED',
+    UNKNOWN: 'UNKNOWN'
+  }
 }

--- a/test/commands/app/deploy.test.js
+++ b/test/commands/app/deploy.test.js
@@ -33,6 +33,9 @@ const authHelper = require('../../../src/lib/auth-helper')
 const mockWebLib = require('@adobe/aio-lib-web')
 const mockRuntimeLib = require('@adobe/aio-lib-runtime')
 
+jest.mock('@adobe/aio-lib-db')
+const mockDbLib = require('@adobe/aio-lib-db')
+
 jest.mock('@adobe/aio-lib-core-config')
 const mockConfig = require('@adobe/aio-lib-core-config')
 
@@ -56,6 +59,7 @@ jest.mock('../../../src/lib/log-forwarding', () => {
   }
 })
 const LogForwarding = require('../../../src/lib/log-forwarding')
+const { DB_STATUS } = require('../../../src/lib/defaults')
 
 const createWebExportAnnotation = (value) => ({
   annotations: { 'web-export': value }
@@ -1634,52 +1638,67 @@ describe('run', () => {
 })
 
 describe('database provisioning', () => {
+  let mockDb
+  beforeEach(() => {
+    mockDb = {
+      provisionStatus: jest.fn(),
+      provisionRequest: jest.fn()
+    }
+    mockDbLib.init.mockResolvedValue(mockDb)
+  })
+
   // Helper functions for unit tests
-  const createDatabaseConfig = (region = null) => ({
+  const createDatabaseConfig = (region = null, provision = true) => ({
+    ow: { namespace: 'test_ns', auth: 'user:pass' },
     manifest: {
       full: {
         database: {
+          'auto-provision': provision,
           ...(region && { region })
         }
       }
     }
   })
 
-  const runProvisionTest = async (config, flags, mockResult) => {
-    const spinner = ora()
+  const runProvisionTest = async (
+    config,
+    flags,
+    spinner,
+    mockResult = { status: DB_STATUS.PROVISIONED, region: 'amer' },
+    mockStatus = { status: DB_STATUS.NOT_PROVISIONED }
+  ) => {
+    if (mockStatus instanceof Error) {
+      mockDb.provisionStatus.mockRejectedValueOnce(mockStatus)
+    } else {
+      mockDb.provisionStatus.mockResolvedValueOnce(mockStatus)
+    }
 
     if (mockResult instanceof Error) {
-      command.config.runCommand.mockRejectedValueOnce(mockResult)
+      mockDb.provisionRequest.mockRejectedValueOnce(mockResult)
     } else {
-      command.config.runCommand.mockResolvedValueOnce(mockResult)
+      mockDb.provisionRequest.mockResolvedValueOnce(mockResult)
     }
 
-    return {
-      result: await command.provisionDatabase(config, spinner, flags).catch(e => { throw e }),
-      spinner
-    }
+    await command.provisionDatabase(config, spinner, flags).catch(e => { throw e })
+    return spinner
   }
 
   test('should provision database when auto-provision is true', async () => {
-    const appConfigWithDb = createAppConfig({
-      ...command.appConfig,
-      manifest: {
-        full: {
-          database: {
-            'auto-provision': true,
-            region: 'emea'
-          }
-        }
-      }
-    })
+    mockDb.provisionStatus.mockResolvedValue({ status: DB_STATUS.NOT_PROVISIONED })
+    mockDb.provisionRequest.mockResolvedValue({ status: DB_STATUS.PROVISIONED, region: 'amer' })
+    const appConfigWithDb = createAppConfig({ ...command.appConfig, ...createDatabaseConfig() })
 
     command.getAppExtConfigs.mockResolvedValueOnce(appConfigWithDb)
-    command.config.runCommand.mockResolvedValue()
 
     await command.run()
 
     expect(command.error).toHaveBeenCalledTimes(0)
-    expect(command.config.runCommand).toHaveBeenCalledWith('app:db:provision', ['--region', 'emea', '--yes'])
+
+    const expectedInitConfig = { ow: { namespace: 'test_ns', auth: 'user:pass' } }
+    expect(mockDbLib.init).toHaveBeenCalledWith(expect.objectContaining(expectedInitConfig))
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.log).toHaveBeenCalledWith(
@@ -1688,23 +1707,19 @@ describe('database provisioning', () => {
   })
 
   test('should not provision database when auto-provision is false', async () => {
-    const appConfigWithoutDb = createAppConfig({
-      ...command.appConfig,
-      manifest: {
-        full: {
-          database: {
-            'auto-provision': false
-          }
-        }
-      }
-    })
+    mockDb.provisionStatus.mockResolvedValue({ status: DB_STATUS.NOT_PROVISIONED })
+    mockDb.provisionRequest.mockResolvedValue({ status: DB_STATUS.PROVISIONED, region: 'emea' })
+
+    const appConfigWithoutDb = createAppConfig({ ...command.appConfig, ...createDatabaseConfig(null, false) })
 
     command.getAppExtConfigs.mockResolvedValueOnce(appConfigWithoutDb)
 
     await command.run()
 
     expect(command.error).toHaveBeenCalledTimes(0)
-    expect(command.config.runCommand).not.toHaveBeenCalledWith('app:db:provision', expect.anything())
+    expect(mockDbLib.init).not.toHaveBeenCalled()
+    expect(mockDb.provisionStatus).not.toHaveBeenCalled()
+    expect(mockDb.provisionRequest).not.toHaveBeenCalled()
     expect(mockRuntimeLib.deployActions).toHaveBeenCalledTimes(1)
     expect(mockWebLib.deployWeb).toHaveBeenCalledTimes(1)
     expect(command.log).toHaveBeenCalledWith(
@@ -1714,55 +1729,238 @@ describe('database provisioning', () => {
 
   //  tests for provisionDatabase method behavior
   test('should run provision command correctly with region', async () => {
-    const config = createDatabaseConfig('emea')
+    const config = createDatabaseConfig('amer')
     const flags = { verbose: false }
+    const spinner = ora()
 
-    const { spinner } = await runProvisionTest(config, flags)
+    await runProvisionTest(config, flags, spinner)
 
-    expect(spinner.start).toHaveBeenCalledWith('Deploying database in region \'emea\'')
-    expect(command.config.runCommand).toHaveBeenCalledWith('app:db:provision', ['--region', 'emea', '--yes'])
-    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Deployed database for application in region \'emea\''))
+    expect(spinner.start).toHaveBeenCalledWith(expect.stringContaining('Deploying database in the \'amer\' region'))
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Database is deployed and ready for use'))
+
+    const expectedInitConfig = {
+      ow: { namespace: 'test_ns', auth: 'user:pass' },
+      region: 'amer'
+    }
+    expect(mockDbLib.init).toHaveBeenCalledWith(expect.objectContaining(expectedInitConfig))
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
   })
 
   test('should run provision command correctly without region', async () => {
     const config = createDatabaseConfig()
     const flags = { verbose: false }
+    const spinner = ora()
 
-    const { spinner } = await runProvisionTest(config, flags)
+    await runProvisionTest(config, flags, spinner)
 
-    expect(spinner.start).toHaveBeenCalledWith('Deploying database in default region')
-    expect(command.config.runCommand).toHaveBeenCalledWith('app:db:provision', ['--yes'])
-    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Deployed database for application'))
+    expect(spinner.start).toHaveBeenCalledWith(expect.stringContaining('Deploying database in the default region'))
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Database is deployed and ready for use'))
+
+    const expectedInitConfig = { ow: { namespace: 'test_ns', auth: 'user:pass' } }
+    expect(mockDbLib.init).toHaveBeenCalledWith(expect.objectContaining(expectedInitConfig))
+    expect(mockDbLib.init).not.toHaveBeenCalledWith(expect.objectContaining({ region: expect.any(String) }))
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
   })
 
   test('should show verbose output with region', async () => {
-    const config = createDatabaseConfig('amer')
+    const config = createDatabaseConfig('apac')
     const flags = { verbose: true }
+    const spinner = ora()
 
-    const { spinner } = await runProvisionTest(config, flags)
+    await runProvisionTest(config, flags, spinner, { status: DB_STATUS.PROVISIONED, region: 'apac' }, { status: DB_STATUS.DELETED })
 
-    expect(spinner.info).toHaveBeenCalledWith(expect.stringContaining('Running: aio app db provision --region amer --yes'))
-    expect(spinner.start).toHaveBeenCalledTimes(2) // Once initially, once after verbose info
-    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Deployed database for application in region \'amer\''))
+    // Existing database status
+    expect(spinner.start).toHaveBeenCalledWith(expect.stringContaining('Checking existing database deployment status...'))
+    expect(spinner.info).toHaveBeenCalledWith(expect.stringContaining('status: DELETED'))
+    // Provision request
+    expect(spinner.start).toHaveBeenCalledWith(expect.stringContaining('in the \'apac\' region...'))
+    expect(spinner.info).toHaveBeenCalledWith(expect.stringContaining('Database provisioning result:'))
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Database is deployed and ready for use'))
   })
 
   test('should show verbose output without region', async () => {
     const config = createDatabaseConfig()
     const flags = { verbose: true }
+    const spinner = ora()
 
-    const { spinner } = await runProvisionTest(config, flags)
+    await runProvisionTest(config, flags, spinner, { status: DB_STATUS.PROVISIONED, region: 'emea' })
 
-    expect(spinner.info).toHaveBeenCalledWith(expect.stringContaining('Running: aio app db provision --yes'))
-    expect(spinner.start).toHaveBeenCalledTimes(2) // Once initially, once after verbose info
-    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Deployed database for application'))
+    // Existing database status
+    expect(spinner.start).toHaveBeenCalledWith(expect.stringContaining('Checking existing database deployment status...'))
+    expect(spinner.info).toHaveBeenCalledWith(expect.stringContaining('status: NOT_PROVISIONED'))
+    // Provision request
+    expect(spinner.start).toHaveBeenCalledWith(expect.stringContaining('in the default region...'))
+    expect(spinner.info).toHaveBeenCalledWith(expect.stringContaining('Database provisioning result:'))
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Database is deployed and ready for use'))
   })
 
   test('should handle provision command failure', async () => {
     const config = createDatabaseConfig('amer')
     const flags = { verbose: false }
     const error = new Error('Database provision failed')
+    const spinner = ora()
 
-    await expect(runProvisionTest(config, flags, error))
+    await expect(runProvisionTest(config, flags, spinner, error))
       .rejects.toThrow('Database provision failed')
+    expect(spinner.fail).toHaveBeenCalled()
+  })
+
+  test('should not provision if database is already provisioned', async () => {
+    const config = createDatabaseConfig('apac')
+    const spinner = ora()
+
+    await runProvisionTest(config, {}, spinner, null, { status: DB_STATUS.PROVISIONED, region: 'apac' })
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).not.toHaveBeenCalled()
+
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('Database is deployed and ready for use'))
+  })
+
+  test('should not provision database if request is pending', async () => {
+    const config = createDatabaseConfig('apac')
+    const spinner = ora()
+
+    await runProvisionTest(config, {}, spinner, null, { status: DB_STATUS.REQUESTED, region: 'apac' })
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).not.toHaveBeenCalled()
+
+    expect(spinner.succeed).toHaveBeenCalledWith(
+      expect.stringContaining('already been submitted')
+    )
+  })
+
+  test('should try to provision if previous request failed', async () => {
+    const config = createDatabaseConfig('apac')
+
+    await runProvisionTest(config, { }, ora(), undefined, { status: DB_STATUS.FAILED, region: 'apac' })
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+  })
+
+  test('should try to provision if database status check fails with verbose flag', async () => {
+    const config = createDatabaseConfig('apac')
+    const spinner = ora()
+
+    await runProvisionTest(config, { verbose: true }, spinner, undefined, new Error('Status check failure'))
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.warn).toHaveBeenCalledWith(expect.stringContaining('status check failed'))
+  })
+
+  test('should try to provision if database status check fails without verbose flag', async () => {
+    const config = createDatabaseConfig('apac')
+    const spinner = ora()
+
+    await runProvisionTest(config, { }, spinner, undefined, new Error('Status check failure'))
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.warn).not.toHaveBeenCalledWith(expect.stringContaining('status check failed'))
+  })
+
+  test('should report success when provision request gets submitted and responds as pending', async () => {
+    const config = createDatabaseConfig()
+    const spinner = ora()
+
+    await runProvisionTest(config, {}, spinner, { status: DB_STATUS.PROCESSING, region: 'apac' })
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.succeed).toHaveBeenCalledWith(expect.stringContaining('request submitted'))
+  })
+
+  test('should report warning when provision request reports unrecognized status', async () => {
+    const config = createDatabaseConfig()
+    const spinner = ora()
+
+    await runProvisionTest(config, {}, spinner, { status: 'OTHER_STATUS' })
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.warn).toHaveBeenCalledWith(expect.stringContaining('unexpected status'))
+  })
+
+  test('should report warning when provision request responds without status', async () => {
+    const config = createDatabaseConfig()
+    const spinner = ora()
+
+    await runProvisionTest(config, {}, spinner, {})
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.warn).toHaveBeenCalledWith(expect.stringContaining('unexpected status'))
+  })
+
+  test('should throw error if provision request returns failure status with known message', async () => {
+    const config = createDatabaseConfig()
+    const spinner = ora()
+
+    await expect(runProvisionTest(config, {}, spinner, { status: DB_STATUS.FAILED, message: 'Could not be provisioned' }))
+      .rejects.toThrow('Could not be provisioned')
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.fail).toHaveBeenCalled()
+  })
+
+  test('should throw error if provision request returns failure status with unknown message', async () => {
+    const config = createDatabaseConfig()
+    const spinner = ora()
+
+    await expect(runProvisionTest(config, {}, spinner, { status: DB_STATUS.REJECTED }))
+      .rejects.toThrow('Unknown error')
+
+    expect(mockDbLib.init).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionStatus).toHaveBeenCalledTimes(1)
+    expect(mockDb.provisionRequest).toHaveBeenCalledTimes(1)
+    expect(spinner.fail).toHaveBeenCalled()
+  })
+
+  test('should throw error if OW auth is missing in config', async () => {
+    const config = createDatabaseConfig()
+    config.ow = { namespace: 'test_ns' } // missing auth
+
+    await expect(runProvisionTest(config, {}, ora())).rejects.toThrow()
+
+    expect(mockDbLib.init).not.toHaveBeenCalled()
+    expect(mockDb.provisionStatus).not.toHaveBeenCalled()
+    expect(mockDb.provisionRequest).not.toHaveBeenCalled()
+  })
+
+  test('should throw error if OW namespace is missing in config', async () => {
+    const config = createDatabaseConfig()
+    config.ow = { auth: 'user:pass' } // missing namespace
+
+    await expect(runProvisionTest(config, {}, ora())).rejects.toThrow()
+
+    expect(mockDbLib.init).not.toHaveBeenCalled()
+    expect(mockDb.provisionStatus).not.toHaveBeenCalled()
+    expect(mockDb.provisionRequest).not.toHaveBeenCalled()
+  })
+
+  test('should throw error if OW config is missing entirely', async () => {
+    const config = createDatabaseConfig()
+    delete config.ow
+
+    await expect(runProvisionTest(config, {}, ora())).rejects.toThrow()
+
+    expect(mockDbLib.init).not.toHaveBeenCalled()
+    expect(mockDb.provisionStatus).not.toHaveBeenCalled()
+    expect(mockDb.provisionRequest).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Execute database provisioning during the `deploy` command via the `@adobe/aio-lib-db` library directly instead of going through another CLI command.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[CEXT-5368: Minimal declarative database provisioning](https://jira.corp.adobe.com/browse/CEXT-5368)
[CEXT-5618: Release declarative database provisioning](https://jira.corp.adobe.com/browse/CEXT-5618)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Follow project convention to call libraries directly instead of going through separate CLI plugins

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Unit testing
* Manual testing with app.config.yaml that includes the `runtimeManifest: database: auto-provision: true` setting

## Screenshots (if appropriate):
Relevant part of the command output when using the `--verbose` flag:
<img width="434" height="156" alt="image" src="https://github.com/user-attachments/assets/463fe0e5-18c8-4b08-996a-ac8d2acac3f8" />

Proof of passing tests and code style:
<img width="357" height="148" alt="image" src="https://github.com/user-attachments/assets/1af497c7-473c-4bab-94cb-12e3067ad52d" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
