### PR TITLE
Add an npm ci --dry-run in aio app pack

### DIFF
--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -57,8 +57,10 @@ class Pack extends BaseCommand {
       .map(([, extConfig]) => path.relative(process.cwd(), extConfig.app.dist))
 
     try {
-      // 0. validate package.json and package-lock.json compatibility
-      await this.validatePackageLockCompatibility()
+      // 0. validate package.json and package-lock.json compatibility (skip if --no-lock-file)
+      if (flags['lock-file']) {
+        await this.validatePackageLockCompatibility()
+      }
 
       // 1. create artifacts phase
       this.spinner.start(`Creating package artifacts folder '${DEFAULTS.ARTIFACTS_FOLDER_PATH}'...`)
@@ -394,7 +396,7 @@ Pack.description = `This command will support packaging apps for redistribution.
 Pack.flags = {
   ...BaseCommand.flags,
   'lock-file': Flags.boolean({
-    description: 'Include the package-lock.json file in the packaged app',
+    description: 'Include the package-lock.json file in the packaged app. When disabled, compatibility validation is skipped since the provisioner will use npm install instead of npm ci.',
     default: true,
     allowNo: true
   }),

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -578,12 +578,6 @@ describe('run', () => {
       }
       return false
     })
-    execa.mockImplementationOnce((cmd, args) => {
-      if (cmd === 'npm' && args[0] === 'ci' && args[1] === '--dry-run') {
-        return Promise.resolve({ stdout: '', stderr: '' })
-      }
-      return Promise.resolve({ stdout: JSON.stringify([{ files: [] }]) })
-    })
 
     // since we already unit test the methods above, we mock it here
     command.copyPackageFiles = jest.fn()
@@ -595,7 +589,8 @@ describe('run', () => {
     command.config = { runHook }
     await command.run()
 
-    expect(execa).toHaveBeenCalledWith('npm', ['ci', '--dry-run'], { cwd: expect.any(String) })
+    const npmCiCalls = execa.mock.calls.filter(call => call[0] === 'npm' && call[1] && call[1][0] === 'ci')
+    expect(npmCiCalls.length).toBe(0)
     expect(command.copyPackageFiles).toHaveBeenCalledTimes(1)
     expect(command.filesToPack).toHaveBeenCalledTimes(1)
     expect(command.filesToPack).toHaveBeenCalledWith({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a compatibility check to the aio app pack command.
It runs npm ci --dry-run to make sure package.json and package-lock.json match before packaging, helping catch issues early and avoid install failures later.

## Motivation and Context
https://jira.corp.adobe.com/browse/ACNA-4288

## How Has This Been Tested?

Added tests covering validation success, failure, and skip scenarios, with full coverage and all tests passing.

Manually verified that validation passes for compatible files, fails with clear errors for incompatible ones, and is skipped when package-lock.json is missing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
