### PR TITLE
fix: normalize oclif v2 plugin hooks for v4 compatibility

### DIFF
--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -43,7 +43,10 @@ class BaseCommand extends Command {
     // Normalize hooks from plugins loaded by oclif v2 into this v4 Config.
     // oclif v2 stores hooks as string arrays; v4 expects {identifier, target} objects.
     // Only mutate when string hooks are present; guard against frozen plugin references.
-    for (const plugin of this.config.getPluginsList()) {
+    const pluginList = typeof this.config.getPluginsList === 'function'
+      ? this.config.getPluginsList()
+      : [...(this.config.plugins?.values() ?? [])]
+    for (const plugin of pluginList) {
       if (!plugin.hooks) {
         continue
       }

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -55,13 +55,7 @@ class BaseCommand extends Command {
         if (!hooksArr.some(h => typeof h === 'string')) {
           continue
         }
-        try {
-          plugin.hooks[event] = hooksArr.map(h =>
-            typeof h === 'string' ? { identifier: 'default', target: h } : h
-          )
-        } catch (e) {
-          // plugin hooks object is frozen or sealed; skip normalization for this event
-        }
+        plugin.hooks[event] = hooksArr.map(h =>
           typeof h === 'string' ? { identifier: 'default', target: h } : h
         )
       }

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -55,9 +55,13 @@ class BaseCommand extends Command {
         if (!hooksArr.some(h => typeof h === 'string')) {
           continue
         }
-        plugin.hooks[event] = hooksArr.map(h =>
-          typeof h === 'string' ? { identifier: 'default', target: h } : h
-        )
+        try {
+          plugin.hooks[event] = hooksArr.map(h =>
+            typeof h === 'string' ? { identifier: 'default', target: h } : h
+          )
+        } catch {
+          // plugin.hooks is frozen or sealed; skip normalization for this event
+        }
       }
     }
 

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -40,6 +40,17 @@ class BaseCommand extends Command {
 
   async init () {
     await super.init()
+    // Normalize hooks from plugins loaded by oclif v2 into this v4 Config.
+    // oclif v2 stores hooks as string arrays; v4 expects {identifier, target} objects.
+    for (const plugin of this.config.getPluginsList()) {
+      if (!plugin.hooks) continue
+      for (const [event, hooks] of Object.entries(plugin.hooks)) {
+        plugin.hooks[event] = (Array.isArray(hooks) ? hooks : [hooks]).map(h =>
+          typeof h === 'string' ? { identifier: 'default', target: h } : h
+        )
+      }
+    }
+
     // setup a prompt that outputs to stderr
     this.prompt = inquirer.createPromptModule({ output: process.stderr })
 

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -55,7 +55,13 @@ class BaseCommand extends Command {
         if (!hooksArr.some(h => typeof h === 'string')) {
           continue
         }
-        plugin.hooks[event] = hooksArr.map(h =>
+        try {
+          plugin.hooks[event] = hooksArr.map(h =>
+            typeof h === 'string' ? { identifier: 'default', target: h } : h
+          )
+        } catch (e) {
+          // plugin hooks object is frozen or sealed; skip normalization for this event
+        }
           typeof h === 'string' ? { identifier: 'default', target: h } : h
         )
       }

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -42,10 +42,17 @@ class BaseCommand extends Command {
     await super.init()
     // Normalize hooks from plugins loaded by oclif v2 into this v4 Config.
     // oclif v2 stores hooks as string arrays; v4 expects {identifier, target} objects.
+    // Only mutate when string hooks are present; guard against frozen plugin references.
     for (const plugin of this.config.getPluginsList()) {
-      if (!plugin.hooks) continue
+      if (!plugin.hooks) {
+        continue
+      }
       for (const [event, hooks] of Object.entries(plugin.hooks)) {
-        plugin.hooks[event] = (Array.isArray(hooks) ? hooks : [hooks]).map(h =>
+        const hooksArr = Array.isArray(hooks) ? hooks : [hooks]
+        if (!hooksArr.some(h => typeof h === 'string')) {
+          continue
+        }
+        plugin.hooks[event] = hooksArr.map(h =>
           typeof h === 'string' ? { identifier: 'default', target: h } : h
         )
       }

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -294,7 +294,8 @@ test('init normalizes oclif v2 string hooks to v4 object format', async () => {
     hooks: {
       'pre-deploy-event-reg': ['./src/hooks/pre-deploy-event-reg.js'],
       'post-deploy-event-reg': './src/hooks/post-deploy-event-reg.js',
-      'already-v4': [{ identifier: 'default', target: './src/hooks/foo.js' }]
+      'already-v4': [{ identifier: 'default', target: './src/hooks/foo.js' }],
+      'mixed': ['./src/hooks/string.js', { identifier: 'named', target: './src/hooks/obj.js' }]
     }
   }
   cmd.config = global.createOclifMockConfig({
@@ -304,6 +305,10 @@ test('init normalizes oclif v2 string hooks to v4 object format', async () => {
   expect(plugin.hooks['pre-deploy-event-reg']).toEqual([{ identifier: 'default', target: './src/hooks/pre-deploy-event-reg.js' }])
   expect(plugin.hooks['post-deploy-event-reg']).toEqual([{ identifier: 'default', target: './src/hooks/post-deploy-event-reg.js' }])
   expect(plugin.hooks['already-v4']).toEqual([{ identifier: 'default', target: './src/hooks/foo.js' }])
+  expect(plugin.hooks['mixed']).toEqual([
+    { identifier: 'default', target: './src/hooks/string.js' },
+    { identifier: 'named', target: './src/hooks/obj.js' }
+  ])
 })
 
 test('init skips plugins with no hooks', async () => {
@@ -314,6 +319,18 @@ test('init skips plugins with no hooks', async () => {
   })
   await expect(cmd.init()).resolves.not.toThrow()
 })
+
+test('init does not mutate hooks already in v4 format', async () => {
+  const cmd = new TheCommand([])
+  const original = [{ identifier: 'default', target: './src/hooks/foo.js' }]
+  const plugin = { hooks: { 'some-event': original } }
+  cmd.config = global.createOclifMockConfig({
+    getPluginsList: jest.fn().mockReturnValue([plugin])
+  })
+  await cmd.init()
+  expect(plugin.hooks['some-event']).toBe(original) // same reference, not replaced
+})
+
 
 test('catch', async () => {
   const cmd = new TheCommand([])

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -331,6 +331,27 @@ test('init does not mutate hooks already in v4 format', async () => {
   expect(plugin.hooks['some-event']).toBe(original) // same reference, not replaced
 })
 
+test('init falls back to this.config.plugins Map when getPluginsList is unavailable', async () => {
+  const cmd = new TheCommand([])
+  const plugin = { hooks: { 'pre-deploy-event-reg': ['./src/hooks/hook.js'] } }
+  const mockConfig = global.createOclifMockConfig({
+    plugins: new Map([['test-plugin', plugin]])
+  })
+  delete mockConfig.getPluginsList
+  cmd.config = mockConfig
+  await cmd.init()
+  expect(plugin.hooks['pre-deploy-event-reg']).toEqual([{ identifier: 'default', target: './src/hooks/hook.js' }])
+})
+
+test('init handles config with neither getPluginsList nor plugins without throwing', async () => {
+  const cmd = new TheCommand([])
+  const mockConfig = global.createOclifMockConfig()
+  delete mockConfig.getPluginsList
+  delete mockConfig.plugins
+  cmd.config = mockConfig
+  await expect(cmd.init()).resolves.not.toThrow()
+})
+
 
 test('catch', async () => {
   const cmd = new TheCommand([])

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -295,7 +295,7 @@ test('init normalizes oclif v2 string hooks to v4 object format', async () => {
       'pre-deploy-event-reg': ['./src/hooks/pre-deploy-event-reg.js'],
       'post-deploy-event-reg': './src/hooks/post-deploy-event-reg.js',
       'already-v4': [{ identifier: 'default', target: './src/hooks/foo.js' }],
-      'mixed': ['./src/hooks/string.js', { identifier: 'named', target: './src/hooks/obj.js' }]
+      mixed: ['./src/hooks/string.js', { identifier: 'named', target: './src/hooks/obj.js' }]
     }
   }
   cmd.config = global.createOclifMockConfig({
@@ -351,7 +351,6 @@ test('init handles config with neither getPluginsList nor plugins without throwi
   cmd.config = mockConfig
   await expect(cmd.init()).resolves.not.toThrow()
 })
-
 
 test('catch', async () => {
   const cmd = new TheCommand([])

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -352,6 +352,17 @@ test('init handles config with neither getPluginsList nor plugins without throwi
   await expect(cmd.init()).resolves.not.toThrow()
 })
 
+test('init skips normalization gracefully when plugin hooks object is frozen', async () => {
+  const cmd = new TheCommand([])
+  const plugin = { hooks: Object.freeze({ 'pre-deploy-event-reg': ['./src/hooks/hook.js'] }) }
+  cmd.config = global.createOclifMockConfig({
+    getPluginsList: jest.fn().mockReturnValue([plugin])
+  })
+  await expect(cmd.init()).resolves.not.toThrow()
+  // hooks remain as-is since the frozen object blocked the assignment
+  expect(plugin.hooks['pre-deploy-event-reg']).toEqual(['./src/hooks/hook.js'])
+})
+
 test('catch', async () => {
   const cmd = new TheCommand([])
   cmd.config = global.createOclifMockConfig()

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -288,6 +288,33 @@ test('init', async () => {
   expect(inquirer.createPromptModule).toHaveBeenCalledWith({ output: process.stderr })
 })
 
+test('init normalizes oclif v2 string hooks to v4 object format', async () => {
+  const cmd = new TheCommand([])
+  const plugin = {
+    hooks: {
+      'pre-deploy-event-reg': ['./src/hooks/pre-deploy-event-reg.js'],
+      'post-deploy-event-reg': './src/hooks/post-deploy-event-reg.js',
+      'already-v4': [{ identifier: 'default', target: './src/hooks/foo.js' }]
+    }
+  }
+  cmd.config = global.createOclifMockConfig({
+    getPluginsList: jest.fn().mockReturnValue([plugin])
+  })
+  await cmd.init()
+  expect(plugin.hooks['pre-deploy-event-reg']).toEqual([{ identifier: 'default', target: './src/hooks/pre-deploy-event-reg.js' }])
+  expect(plugin.hooks['post-deploy-event-reg']).toEqual([{ identifier: 'default', target: './src/hooks/post-deploy-event-reg.js' }])
+  expect(plugin.hooks['already-v4']).toEqual([{ identifier: 'default', target: './src/hooks/foo.js' }])
+})
+
+test('init skips plugins with no hooks', async () => {
+  const cmd = new TheCommand([])
+  const plugin = { name: 'no-hooks-plugin' }
+  cmd.config = global.createOclifMockConfig({
+    getPluginsList: jest.fn().mockReturnValue([plugin])
+  })
+  await expect(cmd.init()).resolves.not.toThrow()
+})
+
 test('catch', async () => {
   const cmd = new TheCommand([])
   cmd.config = global.createOclifMockConfig()

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -53,6 +53,7 @@ global.createOclifMockConfig = (overrides = {}) => ({
   runHook: jest.fn().mockResolvedValue({ successes: [] }),
   runCommand: jest.fn(),
   findCommand: jest.fn(),
+  getPluginsList: jest.fn().mockReturnValue([]),
   ...overrides
 })
 


### PR DESCRIPTION
Fixes #921 

## Summary

- When the global `aio-cli` (oclif v2) invokes commands from this plugin (oclif v4), v4's `Config.load` detects the incoming v2 `Config` and re-uses its `Plugin` objects directly
- oclif v2 stores hooks as plain string arrays (`['./src/hooks/foo.js']`); oclif v4's `runHook` expects `{identifier, target}` objects — so `hook.target` was `undefined`, crashing `path.extname(undefined)` with `ERR_INVALID_ARG_TYPE`
- Fixed by normalizing all plugin hooks to v4 `{identifier, target}` format once in `BaseCommand.init()`, covering every command that calls `this.config.runHook`

## Test plan

- [X] Run `aio app deploy` in a project with `@adobe/aio-cli-plugin-events` linked — confirm the `pre-deploy-event-reg` hook runs without `ERR_INVALID_ARG_TYPE`
- [X] Run `aio app undeploy` — confirm `pre-undeploy-event-reg` hook works
- [X] Run `aio app pack` — confirm `pre-pack` hook works
- [X] Run existing unit tests: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)