### PR TITLE
fix: remove node-abort-controller polyfill breaking Node 24 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "js-yaml": "^4.1.0",
     "junk": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
-    "node-abort-controller": "^3.1.1",
     "open": "^8.4.2",
     "ora": "^5",
     "pure-http": "^3",

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -10,9 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { AbortController } = require('node-abort-controller')
-global.AbortController = AbortController
-
 const { Command, Flags } = require('@oclif/core')
 const chalk = require('chalk')
 const coreConfig = require('@adobe/aio-lib-core-config')


### PR DESCRIPTION
## Summary

- Removes the `node-abort-controller` polyfill from `src/BaseCommand.js` (lines 13-14) that globally replaced the native `AbortController`
- Removes `node-abort-controller` from `package.json` dependencies
- Fixes `aio app init` crashing on Node 24 with `ERR_INVALID_ARG_TYPE: The "eventTargets" argument must be an instance of EventEmitter or EventTarget`

**Root cause:** Node 24 tightened validation in `events.setMaxListeners()` to require true `EventEmitter`/`EventTarget` instances. The polyfill's `AbortSignal` is a plain object, so oclif/core calling `setMaxListeners` with the abort signal during command init triggers the error. The polyfill was originally added for Node ≤16.13 compatibility and has been unnecessary since `engines.node` was bumped to `>=20`.

Fixes [ACNA-4621](https://jira.corp.adobe.com/browse/ACNA-4621)

## Test plan

- [ ] 834 existing tests pass (pre-existing `test/commands/app/test.test.js` SIGSEGV is unrelated, reproduces on `master` without this change)
- [ ] `nvm use 24 && aio app init <name>` no longer crashes during post-template `npm install`
- [ ] `nvm use 22` still works as expected