### PR TITLE
fix: app:pack aborts when Node writes process warnings to api-mesh stderr

### DIFF
--- a/src/commands/app/pack.js
+++ b/src/commands/app/pack.js
@@ -31,6 +31,25 @@ const DEFAULTS = {
   DEPLOY_YAML_FILE_NAME: 'deploy.yaml'
 }
 
+// matches Node process warnings, e.g.
+//   (node:1234) [DEP0040] DeprecationWarning: The `punycode` module is deprecated.
+//   (Use `node --trace-deprecation ...` to show where the warning was created)
+const NODE_WARNING_LINE = /^\(node:\d+\)|^\(Use `node --trace-/
+
+/**
+ * Removes Node process warning lines from a child process' stderr.
+ *
+ * @param {string} stderr the raw stderr of a child process
+ * @returns {string} the stderr with any Node process warnings removed
+ */
+function stripNodeWarnings (stderr) {
+  return (stderr ?? '')
+    .split('\n')
+    .filter(line => !NODE_WARNING_LINE.test(line))
+    .join('\n')
+    .trim()
+}
+
 class Pack extends BaseCommand {
   async run () {
     const { args, flags } = await this.parse(Pack)
@@ -195,21 +214,34 @@ class Pack extends BaseCommand {
     if (command) {
       try {
         this.spinner.start('Getting api-mesh config...')
-        const { stdout, stderr } = await execa('aio', ['api-mesh', 'get', '--json'], { cwd: process.cwd() })
+        // the child's stderr is used below to detect the "no mesh" case, so Node process
+        // warnings (e.g. DEP0040 punycode) must not pollute it. NODE_NO_WARNINGS is used
+        // rather than NODE_OPTIONS so that a user-set NODE_OPTIONS is preserved (execa
+        // merges `env` with process.env by default).
+        const { stdout, stderr } = await execa('aio', ['api-mesh', 'get', '--json'], {
+          cwd: process.cwd(),
+          env: { NODE_NO_WARNINGS: '1' }
+        })
 
-        if (stderr) {
-          throw new Error(stderr)
+        // defensively strip any Node process-warning lines that still reach stderr
+        const meshStderr = stripNodeWarnings(stderr)
+
+        if (meshStderr) {
+          throw new Error(meshStderr)
         }
 
         meshConfig = JSON.parse(stdout).meshConfig
         aioLogger.debug(`api-mesh:get - ${JSON.stringify(meshConfig, null, 2)}`)
         this.spinner.succeed('Got api-mesh config')
       } catch (err) {
-        // Ignore error if no mesh found, otherwise throw
-        if (err?.message.includes('Error: Unable to get mesh config.')) {
+        // Ignore error if no mesh found, otherwise throw.
+        // Thrown execa errors carry the child's output on `stderr`, which is not always
+        // reflected in `message` (and `message` is absent entirely for non-Error throws).
+        const details = [err?.message, err?.stderr].filter(Boolean).join('\n')
+        if (details.includes('Unable to get mesh config.')) {
           aioLogger.debug('No api-mesh config found')
         } else {
-          console.error(err)
+          aioLogger.debug(`api-mesh:get failed - ${details || err}`)
           throw err
         }
       }

--- a/test/commands/app/pack.test.js
+++ b/test/commands/app/pack.test.js
@@ -204,7 +204,97 @@ test('createDeployYamlFile (1 extension), no api-mesh, plugin throws error', asy
     }
   })
 
-  await expect(command.createDeployYamlFile(extConfig)).rejects.toEqual(TypeError('Cannot read properties of undefined (reading \'includes\')'))
+  // the thrown value carries the "no mesh" message on `stderr` and has no `message`,
+  // so it must be treated as "no mesh found" rather than crashing on `message.includes`
+  await command.createDeployYamlFile(extConfig)
+
+  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('dist', 'app-package', 'deploy.yaml'))
+  await expect(importHelper.writeFile.mock.calls[0][1]).toMatchFixture('pack/2.deploy.no-mesh.yaml')
+  await expect(importHelper.writeFile.mock.calls[0][2]).toMatchObject({ overwrite: true })
+})
+
+test('createDeployYamlFile (1 extension), api-mesh stderr has Node process warnings', async () => {
+  const extConfig = fixtureJson('pack/2.all.config.json')
+  const meshOutput = fixtureFile('pack/3.api-mesh.get.json')
+
+  const command = new TheCommand()
+  command.argv = []
+  command.config = {
+    findCommand: jest.fn().mockReturnValue({}),
+    runCommand: jest.fn(),
+    runHook: jest.fn().mockResolvedValue({ successes: [] })
+  }
+
+  execa.mockImplementationOnce((cmd, args, opts) => {
+    expect(cmd).toEqual('aio')
+    expect(args).toEqual(['api-mesh', 'get', '--json'])
+    // Node process warnings must be suppressed in the child
+    expect(opts.env).toMatchObject({ NODE_NO_WARNINGS: '1' })
+
+    return {
+      stdout: meshOutput,
+      stderr: [
+        '(node:12345) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.',
+        '(Use `node --trace-deprecation ...` to show where the warning was created)'
+      ].join('\n')
+    }
+  })
+
+  // warnings on stderr are not errors: the mesh config must still be picked up
+  await command.createDeployYamlFile(extConfig)
+
+  await expect(importHelper.writeFile.mock.calls[0][0]).toMatch(path.join('dist', 'app-package', 'deploy.yaml'))
+  await expect(importHelper.writeFile.mock.calls[0][1]).toMatchFixture('pack/2.deploy.yaml')
+  await expect(importHelper.writeFile.mock.calls[0][2]).toMatchObject({ overwrite: true })
+})
+
+test('createDeployYamlFile (1 extension), api-mesh real error mixed with Node process warnings', async () => {
+  const extConfig = fixtureJson('pack/2.all.config.json')
+
+  const command = new TheCommand()
+  command.argv = []
+  command.config = {
+    findCommand: jest.fn().mockReturnValue({}),
+    runCommand: jest.fn(),
+    runHook: jest.fn().mockResolvedValue({ successes: [] })
+  }
+
+  execa.mockImplementationOnce((cmd, args) => {
+    expect(cmd).toEqual('aio')
+    expect(args).toEqual(['api-mesh', 'get', '--json'])
+
+    return {
+      stderr: [
+        '(node:12345) [DEP0040] DeprecationWarning: The `punycode` module is deprecated.',
+        'Error: api-mesh service is unavailable'
+      ].join('\n')
+    }
+  })
+
+  // the warning is stripped, the real error is still surfaced
+  await expect(command.createDeployYamlFile(extConfig)).rejects.toEqual(Error('Error: api-mesh service is unavailable'))
+})
+
+test('createDeployYamlFile (1 extension), api-mesh throws a value with no message or stderr', async () => {
+  const extConfig = fixtureJson('pack/2.all.config.json')
+
+  const command = new TheCommand()
+  command.argv = []
+  command.config = {
+    findCommand: jest.fn().mockReturnValue({}),
+    runCommand: jest.fn(),
+    runHook: jest.fn().mockResolvedValue({ successes: [] })
+  }
+
+  execa.mockImplementationOnce((cmd, args) => {
+    expect(cmd).toEqual('aio')
+    expect(args).toEqual(['api-mesh', 'get', '--json'])
+    // eslint-disable-next-line no-throw-literal
+    throw { code: 'ENOENT' }
+  })
+
+  // must rethrow the original value, not crash while inspecting it
+  await expect(command.createDeployYamlFile(extConfig)).rejects.toEqual({ code: 'ENOENT' })
 })
 
 test('createDeployYamlFile (1 extension), api-mesh get call throws non 404 error', async () => {


### PR DESCRIPTION
## Description

`createDeployYamlFile` treats **any** output on the `aio api-mesh get --json` child's stderr as a fatal error:

```js
if (stderr) {
  throw new Error(stderr)
}
```

Node process warnings go to stderr while the command still exits `0`. On Node 22 the `punycode` deprecation (`DEP0040`) is emitted on virtually every `aio` invocation, so a **successful** mesh lookup aborts `app:pack`, surfacing the deprecation notice as the error.

Importantly, the `if (stderr) throw` is **not** redundant and is deliberately kept: it is how the "no mesh" case is detected, because `api-mesh:get` reports that via `this.error(msg, { exit: false })` — which writes to stderr and exits `0`. So instead of removing the check, this PR keeps it and removes only the noise:

- pass `NODE_NO_WARNINGS: '1'` to the child, suppressing Node process warnings at the source. `NODE_NO_WARNINGS` is used rather than `NODE_OPTIONS` so that a user-set `NODE_OPTIONS` is preserved (execa merges `env` with `process.env` by default).
- strip any residual `(node:NNN) …` / ``(Use `node --trace-…`)`` lines via a small `stripNodeWarnings` helper, as a backstop for warnings arriving from a wrapper or `--require` preload.

**Behaviour is otherwise unchanged** — genuine api-mesh errors still abort `app:pack` exactly as before.

### Secondary fix in the same block

```js
if (err?.message.includes('Error: Unable to get mesh config.')) {
```

The optional chaining stops one level short: a thrown value with no `message` (a non-`Error` throw, or an execa error carrying output only on `stderr`) raises `TypeError: Cannot read properties of undefined (reading 'includes')` inside the catch, masking the original failure. It now inspects `message` **and** `stderr`, so a "no mesh" report is recognised however it arrives, and anything unrecognised is rethrown untouched.

`console.error(err)` is replaced with `aioLogger.debug` — it bypassed the logger used everywhere else in the file and double-reported, since `err` is rethrown on the next line.

The `'Error: '` prefix was also dropped from the matched substring so the check doesn't depend on oclif's error styling.

## Related Issue

Fixes #930

## Motivation and Context

`app:pack` is currently unusable on Node 22 for any project where the api-mesh plugin is installed, which is the default in recent `@adobe/aio-cli` releases. The failure is confusing because the reported error is a deprecation warning rather than anything to do with packaging.

## How Has This Been Tested?

`npx jest -c jest.config.js test/commands/app/pack.test.js` — **35 passed**, with `pack.js` at **100%** statements/branches/functions/lines (the repo's global threshold). `npx eslint src test` is clean.

One existing test is updated. It asserted the `TypeError` above as expected behaviour:

```js
await expect(command.createDeployYamlFile(extConfig)).rejects.toEqual(TypeError('Cannot read properties of undefined (reading \'includes\')'))
```

The mocked throw carries `stderr: 'Error: Unable to get mesh config. No mesh found for Org'` — a "no mesh" report — so it now asserts that the no-mesh `deploy.yaml` fixture is written instead of the command crashing.

Three tests are added:

- api-mesh stderr containing only Node process warnings → mesh config still read, and `NODE_NO_WARNINGS` asserted on the execa options
- a real error mixed in with Node warnings → warning stripped, real error still surfaced
- a thrown value with neither `message` nor `stderr` → original value rethrown, no `TypeError`

The existing `api-mesh service is unavailable` and `no api-mesh` tests pass unmodified, which is the main guard that error semantics are unchanged.

Verified end-to-end against a real App Builder project on Node v22.22.2: before the change `app:pack` aborted with the `DEP0040` notice; after it, the mesh lookup no longer misreports the warning as a failure.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

### One question for maintainers

Should a *genuine* api-mesh failure abort `app:pack` at all? `meshConfig` is optional in `deploy.yaml`, yet an unrelated auth/org problem currently fails the entire packaging step even for apps with no mesh. I hit this with `User does not belong to the organization.` on a project that doesn't use api-mesh — under `--json`, oclif serialises that to `{"error":{"oclif":{"exit":2}}}`, so the message needed for classification is lost entirely.

I've deliberately left that behaviour alone here to keep this PR a pure bug fix. Happy to follow up with a separate PR making the lookup non-fatal (warn and continue) if that's the direction you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)