### PR TITLE
fix: bump archiver ^5->^7 and unzipper ^0.10->^0.12 to drop deprecated transitive deps (APPBLD-4609)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@parcel/reporter-cli": "^2.7.0",
     "ajv": "^8",
     "ajv-formats": "^2.1.1",
-    "archiver": "^5.3.1",
+    "archiver": "^7.0.1",
     "chalk": "^4",
     "chokidar": "^3.5.2",
     "execa": "^5.0.0",
@@ -43,7 +43,7 @@
     "pure-http": "^3",
     "serve-static": "^1.14.1",
     "term-size": "^2.2.1",
-    "unzipper": "^0.10.11",
+    "unzipper": "^0.12.5",
     "upath": "^2",
     "which": "^4.0.0",
     "yeoman-environment": "^4.4.3"


### PR DESCRIPTION
## What
- `archiver` `^5.3.1 → ^7.0.1`
- `unzipper` `^0.10.11 → ^0.12.5`

Both are the highest **CommonJS-compatible** targets (archiver@8 is ESM-only), keeping this a drop-in dependency cleanup with no source changes.

## Why
These two direct deps pull deprecated transitive packages:

- `archiver@5` → `archiver-utils@2/3` → `glob@7` → **`inflight@1.0.6`** (deprecated, "leaks memory"). archiver@7 drops this chain.
- `unzipper@0.10` → **`fstream@1.0.12`** (unsupported) → **`rimraf@2.7.1`** (deprecated). unzipper@0.12 removes both.

## Evidence — clean `npm install` deprecation warnings: **18 → 16**

Eliminated by this PR:
```
- npm warn deprecated fstream@1.0.12: This package is no longer supported.
- npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
```

The remaining `glob@7`/`glob@8`/`inflight` warnings are **co-driven by other dependency chains** and are intentionally out of scope here:
- transitive `archiver@6` from `@adobe/aio-lib-runtime` (addressed by adobe/aio-lib-runtime#234)
- `yeoman-generator@5` (via `@adobe/generator-aio-app`)
- `jest@29` (devDependency)

So the archiver bump's benefit is partly masked until those land — but it is required so the eventual full cleanup resolves.

## Validation
- ✅ Unit tests: introduces **no new failures** vs. baseline (the 6 currently-failing oclif command suites fail identically on `master` — a pre-existing Node 26 + `@oclif/core` dynamic-import/Jest issue, unrelated to these deps).
- ✅ Lint clean.
- ✅ Un-mocked round-trip smoke of the real code paths: `pack.js` `zipHelper` (archiver `directory`/`file`/`finalize`) → `install.js` `validateZipDirectoryStructure` (`unzipper.Parse({forceStream})`) → `unzipFile` (`unzipper.Open.file().extract()`), with content verified after extraction.

## Notes
Supersedes #915 (dependabot unzipper 0.10→0.12.3) — this PR takes unzipper to 0.12.5 and additionally bumps archiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)