### PR TITLE
fix: run jest with --experimental-vm-modules for @oclif/core v4 dynamic imports (APPBLD-5077)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/jest": "^29",
     "babel-runtime": "^6.26.0",
     "core-js": "^3",
+    "cross-env": "^7.0.3",
     "eol": "^0.9.1",
     "eslint": "^9",
     "eslint-plugin-jsdoc": "^48.11.0",
@@ -92,7 +93,7 @@
     "lint-fix": "npm run lint -- --fix",
     "prepack": "oclif manifest && oclif readme --no-aliases",
     "test": "npm run unit-tests && npm run lint",
-    "unit-tests": "jest -c jest.config.js",
+    "unit-tests": "cross-env NODE_OPTIONS=--experimental-vm-modules jest -c jest.config.js",
     "version": "oclif readme --no-aliases && git add README.md",
     "update-openwhisk-runtimes": "node bin/openwhisk-standalone-config/get-runtimes.js > bin/openwhisk-standalone-config/runtimes.json"
   },


### PR DESCRIPTION
## Problem
CI on `master` (and the daily *"npm install and run all unit tests"* job, red since ~Aug 23) fails. The command-loading suites — `use`, `add/ci`, `add/event`, `add/service`, `create`, `delete/service` — throw:

```
TypeError: A dynamic import callback was invoked without --experimental-vm-modules
```

## Root cause
`@oclif/core` v4 loads commands via dynamic `import()`. This repo commits **no lockfile**, so CI floats `@oclif/core` to the latest 4.x, and the `unit-tests` script ran plain `jest -c jest.config.js` **without** `--experimental-vm-modules`, so Jest can't execute the dynamic import. (Sibling repo `@adobe/aio-cli-plugin-app-templates` already runs jest with this flag and passes.)

## Fix
- Add `cross-env` devDependency (Windows-runner safe).
- `unit-tests`: `cross-env NODE_OPTIONS=--experimental-vm-modules jest -c jest.config.js`.

## Validation
Clean install + full suite:
- ✅ **56 suites / 853 tests pass, 100% coverage**
- ✅ Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)