### PR TITLE
chore: release 14.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-cli-plugin-app",
   "description": "Create, Build and Deploy Adobe I/O Applications",
-  "version": "14.8.1",
+  "version": "14.8.2",
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-app/issues",
   "dependencies": {


### PR DESCRIPTION
Release 14.8.2 (patch) — publishes the already-merged deprecation fix to npm. Version-bump routed through a PR so it lands on the protected branch via required checks; on-push-publish-to-npm then publishes. Only change: package.json version bump. (Tag + GitHub Release created manually post-merge.)