### PR TITLE
fix: bump @adobe/aio-lib-ims ^7 -> ^8 to drop deprecated uuid@8 (APPBLD-4864)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@adobe/aio-lib-core-networking": "^5",
     "@adobe/aio-lib-db": "^1.0.0",
     "@adobe/aio-lib-env": "^3",
-    "@adobe/aio-lib-ims": "^7",
+    "@adobe/aio-lib-ims": "^8",
     "@adobe/aio-lib-runtime": "^7.1.3",
     "@adobe/aio-lib-templates": "^3",
     "@adobe/aio-lib-web": "^7.0.6",


### PR DESCRIPTION
Bumps @adobe/aio-lib-ims ^7 -> ^8. ims@7 pulls aio-lib-state@3 -> @azure/cosmos@3 -> uuid@8 (deprecated) + carries a high-severity advisory; ims@8 uses aio-lib-state@5 (no cosmos). Real dependency bump (npm overrides do not reach npm-i-g consumers). Validated: ims resolves 8.1.2; deep import require(@adobe/aio-lib-ims/src/context) (CLI) works; getToken/context API unchanged. NOTE: fully clears uuid@8 only alongside the other ims@^7 pinners (aio-cli-plugin-console, aio-cli-plugin-events, @adobe/generator-app-common-lib).